### PR TITLE
[Feat]add service version in eureka metadata

### DIFF
--- a/linkis-dist/bin/install.sh
+++ b/linkis-dist/bin/install.sh
@@ -291,14 +291,16 @@ then
   export GATEWAY_INSTALL_IP=$SERVER_IP
 fi
 
+currentTime=`date +%Y%m%d%H%M%S`
+
 ##eureka
 sed -i ${txt}  "s#defaultZone:.*#defaultZone: $EUREKA_URL#g" $LINKIS_HOME/conf/application-eureka.yml
 sed -i ${txt}  "s#port:.*#port: $EUREKA_PORT#g" $LINKIS_HOME/conf/application-eureka.yml
-sed -i ${txt}  "s#service.version:.*#service.version: $LINKIS_VERSION#g" $LINKIS_HOME/conf/application-eureka.yml
+sed -i ${txt}  "s#linkis.version:.*#linkis.version: $LINKIS_VERSION-$currentTime#g" $LINKIS_HOME/conf/application-eureka.yml
 
 ##server application.yml
 sed -i ${txt}  "s#defaultZone:.*#defaultZone: $EUREKA_URL#g" $LINKIS_HOME/conf/application-linkis.yml
-sed -i ${txt}  "s#service.version:.*#service.version: $LINKIS_VERSION#g" $LINKIS_HOME/conf/application-linkis.yml
+sed -i ${txt}  "s#linkis.version:.*#linkis.version: $LINKIS_VERSION-$currentTime#g" $LINKIS_HOME/conf/application-linkis.yml
 
 echo "update conf $common_conf"
 sed -i ${txt}  "s#wds.linkis.server.version.*#wds.linkis.server.version=$LINKIS_SERVER_VERSION#g" $common_conf

--- a/linkis-dist/bin/install.sh
+++ b/linkis-dist/bin/install.sh
@@ -342,17 +342,19 @@ sed -i ${txt}  "s#wds.linkis.ldap.proxy.baseDN.*#wds.linkis.ldap.proxy.baseDN=$L
 sed -i ${txt}  "s#wds.linkis.ldap.proxy.userNameFormat.*#wds.linkis.ldap.proxy.userNameFormat=$LDAP_USER_NAME_FORMAT#g" $gateway_conf
 sed -i ${txt}  "s#wds.linkis.admin.user.*#wds.linkis.admin.user=$deployUser#g" $gateway_conf
 sed -i ${txt}  "s#\#wds.linkis.admin.password.*#wds.linkis.admin.password=$deployPwd#g" $gateway_conf
+
 if [ "$GATEWAY_PORT" != "" ]
 then
   sed -i ${txt}  "s#spring.server.port.*#spring.server.port=$GATEWAY_PORT#g" $gateway_conf
 fi
-
+sed -i ${txt}  "s#spring.eureka.instance.metadata-map.linkis.conf.version.*#spring.eureka.instance.metadata-map.linkis.conf.version=$LINKIS_VERSION-$currentTime#g" $gateway_conf
 
 manager_conf=$LINKIS_HOME/conf/linkis-cg-linkismanager.properties
 if [ "$MANAGER_PORT" != "" ]
 then
   sed -i ${txt}  "s#spring.server.port.*#spring.server.port=$MANAGER_PORT#g" $manager_conf
 fi
+sed -i ${txt}  "s#spring.eureka.instance.metadata-map.linkis.conf.version.*#spring.eureka.instance.metadata-map.linkis.conf.version=$LINKIS_VERSION-$currentTime#g" $manager_conf
 
 # ecm install
 ecm_conf=$LINKIS_HOME/conf/linkis-cg-engineconnmanager.properties
@@ -360,6 +362,7 @@ if test -z $ENGINECONN_ROOT_PATH
 then
   ENGINECONN_ROOT_PATH=$LINKIS_HOME/engineroot
 fi
+
 sed -i ${txt}  "s#wds.linkis.engineconn.root.dir.*#wds.linkis.engineconn.root.dir=$ENGINECONN_ROOT_PATH#g" $ecm_conf
 
 if [ ! -d $ENGINECONN_ROOT_PATH ] ;then
@@ -373,11 +376,16 @@ then
   sed -i ${txt}  "s#spring.server.port.*#spring.server.port=$ENGINECONNMANAGER_PORT#g" $ecm_conf
 fi
 
+sed -i ${txt}  "s#spring.eureka.instance.metadata-map.linkis.conf.version.*#spring.eureka.instance.metadata-map.linkis.conf.version=$LINKIS_VERSION-$currentTime#g" $ecm_conf
+
 entrance_conf=$LINKIS_HOME/conf/linkis-cg-entrance.properties
 if [ "$ENTRANCE_PORT" != "" ]
 then
   sed -i ${txt}  "s#spring.server.port.*#spring.server.port=$ENTRANCE_PORT#g" $entrance_conf
 fi
+
+sed -i ${txt}  "s#spring.eureka.instance.metadata-map.linkis.conf.version.*#spring.eureka.instance.metadata-map.linkis.conf.version=$LINKIS_VERSION-$currentTime#g" $entrance_conf
+
 if [ "$RESULT_SET_ROOT_PATH" != "" ]
 then
   sed -i ${txt}  "s#wds.linkis.resultSet.store.path.*#wds.linkis.resultSet.store.path=$RESULT_SET_ROOT_PATH#g" $entrance_conf
@@ -388,6 +396,8 @@ if [ "$PUBLICSERVICE_PORT" != "" ]
 then
   sed -i ${txt}  "s#spring.server.port.*#spring.server.port=$PUBLICSERVICE_PORT#g" $publicservice_conf
 fi
+
+sed -i ${txt}  "s#spring.eureka.instance.metadata-map.linkis.conf.version.*#spring.eureka.instance.metadata-map.linkis.conf.version=$LINKIS_VERSION-$currentTime#g" $publicservice_conf
 
 echo "update conf $publicservice_conf"
 if [ "$HIVE_META_URL" != "" ]

--- a/linkis-dist/bin/install.sh
+++ b/linkis-dist/bin/install.sh
@@ -294,9 +294,11 @@ fi
 ##eureka
 sed -i ${txt}  "s#defaultZone:.*#defaultZone: $EUREKA_URL#g" $LINKIS_HOME/conf/application-eureka.yml
 sed -i ${txt}  "s#port:.*#port: $EUREKA_PORT#g" $LINKIS_HOME/conf/application-eureka.yml
+sed -i ${txt}  "s#service.version:.*#service.version: $LINKIS_VERSION#g" $LINKIS_HOME/conf/application-eureka.yml
 
 ##server application.yml
 sed -i ${txt}  "s#defaultZone:.*#defaultZone: $EUREKA_URL#g" $LINKIS_HOME/conf/application-linkis.yml
+sed -i ${txt}  "s#service.version:.*#service.version: $LINKIS_VERSION#g" $LINKIS_HOME/conf/application-linkis.yml
 
 echo "update conf $common_conf"
 sed -i ${txt}  "s#wds.linkis.server.version.*#wds.linkis.server.version=$LINKIS_SERVER_VERSION#g" $common_conf

--- a/linkis-dist/bin/install.sh
+++ b/linkis-dist/bin/install.sh
@@ -296,11 +296,11 @@ currentTime=`date +%Y%m%d%H%M%S`
 ##eureka
 sed -i ${txt}  "s#defaultZone:.*#defaultZone: $EUREKA_URL#g" $LINKIS_HOME/conf/application-eureka.yml
 sed -i ${txt}  "s#port:.*#port: $EUREKA_PORT#g" $LINKIS_HOME/conf/application-eureka.yml
-sed -i ${txt}  "s#linkis.version:.*#linkis.version: $LINKIS_VERSION-$currentTime#g" $LINKIS_HOME/conf/application-eureka.yml
+sed -i ${txt}  "s#linkis.app.version:.*#linkis.app.version: $LINKIS_VERSION-$currentTime#g" $LINKIS_HOME/conf/application-eureka.yml
 
 ##server application.yml
 sed -i ${txt}  "s#defaultZone:.*#defaultZone: $EUREKA_URL#g" $LINKIS_HOME/conf/application-linkis.yml
-sed -i ${txt}  "s#linkis.version:.*#linkis.version: $LINKIS_VERSION-$currentTime#g" $LINKIS_HOME/conf/application-linkis.yml
+sed -i ${txt}  "s#linkis.app.version:.*#linkis.app.version: $LINKIS_VERSION-$currentTime#g" $LINKIS_HOME/conf/application-linkis.yml
 
 echo "update conf $common_conf"
 sed -i ${txt}  "s#wds.linkis.server.version.*#wds.linkis.server.version=$LINKIS_SERVER_VERSION#g" $common_conf

--- a/linkis-dist/package/conf/application-eureka.yml
+++ b/linkis-dist/package/conf/application-eureka.yml
@@ -25,7 +25,7 @@ eureka:
   instance:
     metadata-map:
       prometheus.path: ${prometheus.path:/actuator/prometheus}
-      service.version: 1.3.1
+      service.version: ${service.version}
     hostname:
 #    preferIpAddress: true
   client:

--- a/linkis-dist/package/conf/application-eureka.yml
+++ b/linkis-dist/package/conf/application-eureka.yml
@@ -25,7 +25,7 @@ eureka:
   instance:
     metadata-map:
       prometheus.path: ${prometheus.path:/actuator/prometheus}
-      service.version: ${service.version}
+      linkis.version: ${linkis.version}
     hostname:
 #    preferIpAddress: true
   client:

--- a/linkis-dist/package/conf/application-eureka.yml
+++ b/linkis-dist/package/conf/application-eureka.yml
@@ -25,6 +25,7 @@ eureka:
   instance:
     metadata-map:
       prometheus.path: ${prometheus.path:/actuator/prometheus}
+      service.version: 1.3.1
     hostname:
 #    preferIpAddress: true
   client:

--- a/linkis-dist/package/conf/application-eureka.yml
+++ b/linkis-dist/package/conf/application-eureka.yml
@@ -25,7 +25,7 @@ eureka:
   instance:
     metadata-map:
       prometheus.path: ${prometheus.path:/actuator/prometheus}
-      linkis.version: ${linkis.version}
+      linkis.app.version: ${linkis.app.version}
     hostname:
 #    preferIpAddress: true
   client:

--- a/linkis-dist/package/conf/application-linkis.yml
+++ b/linkis-dist/package/conf/application-linkis.yml
@@ -17,7 +17,7 @@ eureka:
   instance:
     metadata-map:
       prometheus.path: ${prometheus.path:${prometheus.endpoint}}
-      service.version: ${service.version}
+      linkis.version: ${linkis.version}
   client:
     serviceUrl:
       defaultZone: http://127.0.0.1:20303/eureka/

--- a/linkis-dist/package/conf/application-linkis.yml
+++ b/linkis-dist/package/conf/application-linkis.yml
@@ -17,7 +17,7 @@ eureka:
   instance:
     metadata-map:
       prometheus.path: ${prometheus.path:${prometheus.endpoint}}
-      service.version: 1.3.1
+      service.version: ${service.version}
   client:
     serviceUrl:
       defaultZone: http://127.0.0.1:20303/eureka/

--- a/linkis-dist/package/conf/application-linkis.yml
+++ b/linkis-dist/package/conf/application-linkis.yml
@@ -17,6 +17,7 @@ eureka:
   instance:
     metadata-map:
       prometheus.path: ${prometheus.path:${prometheus.endpoint}}
+      service.version: 1.3.1
   client:
     serviceUrl:
       defaultZone: http://127.0.0.1:20303/eureka/

--- a/linkis-dist/package/conf/application-linkis.yml
+++ b/linkis-dist/package/conf/application-linkis.yml
@@ -17,7 +17,7 @@ eureka:
   instance:
     metadata-map:
       prometheus.path: ${prometheus.path:${prometheus.endpoint}}
-      linkis.version: ${linkis.version}
+      linkis.app.version: ${linkis.app.version}
   client:
     serviceUrl:
       defaultZone: http://127.0.0.1:20303/eureka/

--- a/linkis-dist/package/conf/linkis-cg-engineconnmanager.properties
+++ b/linkis-dist/package/conf/linkis-cg-engineconnmanager.properties
@@ -23,4 +23,4 @@ spring.server.port=9102
 #wds.linkis.engineconn.env.keys=SPARK3_HOME,
 
 ## you may set service version if you want to distinguish different configuration version
-spring.eureka.instance.metadata-map.service.version=v1
+spring.eureka.instance.metadata-map.linkis.conf.version=v1

--- a/linkis-dist/package/conf/linkis-cg-engineconnmanager.properties
+++ b/linkis-dist/package/conf/linkis-cg-engineconnmanager.properties
@@ -21,3 +21,6 @@ wds.linkis.engineconn.root.dir=/appcom/tmp
 spring.server.port=9102
 ##set engine environment in econn start script, such as SPARK3_HOME,the value of env will read from ecm host by key.
 #wds.linkis.engineconn.env.keys=SPARK3_HOME,
+
+## you may set service version if you want to distinguish different configuration version
+spring.eureka.instance.metadata-map.service.version=v1

--- a/linkis-dist/package/conf/linkis-cg-entrance.properties
+++ b/linkis-dist/package/conf/linkis-cg-entrance.properties
@@ -33,4 +33,4 @@ spring.server.port=9104
 wds.linkis.entrance.user.creator.ip.interceptor.switch=false
 
 ## you may set service version if you want to distinguish different configuration version
-spring.eureka.instance.metadata-map.service.version=v1
+spring.eureka.instance.metadata-map.linkis.conf.version=v1

--- a/linkis-dist/package/conf/linkis-cg-entrance.properties
+++ b/linkis-dist/package/conf/linkis-cg-entrance.properties
@@ -28,7 +28,9 @@ wds.linkis.server.user.restful.uri.pass.auth=/actuator/prometheus,/api/rest_j/v1
 ## enable variable operation default vaule false
 # wds.linkis.variable.operation=true
 
-
 ##Spring
 spring.server.port=9104
 wds.linkis.entrance.user.creator.ip.interceptor.switch=false
+
+## you may set service version if you want to distinguish different configuration version
+spring.eureka.instance.metadata-map.service.version=v1

--- a/linkis-dist/package/conf/linkis-cg-linkismanager.properties
+++ b/linkis-dist/package/conf/linkis-cg-linkismanager.properties
@@ -27,3 +27,6 @@ wds.linkis.engineConn.dist.load.enable=true
 
 ##Spring
 spring.server.port=9101
+
+## you may set service version if you want to distinguish different configuration version
+spring.eureka.instance.metadata-map.service.version=v1

--- a/linkis-dist/package/conf/linkis-cg-linkismanager.properties
+++ b/linkis-dist/package/conf/linkis-cg-linkismanager.properties
@@ -29,4 +29,4 @@ wds.linkis.engineConn.dist.load.enable=true
 spring.server.port=9101
 
 ## you may set service version if you want to distinguish different configuration version
-spring.eureka.instance.metadata-map.service.version=v1
+spring.eureka.instance.metadata-map.linkis.conf.version=v1

--- a/linkis-dist/package/conf/linkis-mg-gateway.properties
+++ b/linkis-dist/package/conf/linkis-mg-gateway.properties
@@ -37,4 +37,4 @@ spring.server.port=9001
 wds.linkis.server.component.exclude.classes=org.apache.linkis.server.Knife4jConfig
 
 ## you may set service version if you want to distinguish different configuration version
-spring.eureka.instance.metadata-map.service.version=v1
+spring.eureka.instance.metadata-map.linkis.conf.version=v1

--- a/linkis-dist/package/conf/linkis-mg-gateway.properties
+++ b/linkis-dist/package/conf/linkis-mg-gateway.properties
@@ -35,3 +35,6 @@ wds.linkis.admin.user=hadoop
 spring.server.port=9001
 
 wds.linkis.server.component.exclude.classes=org.apache.linkis.server.Knife4jConfig
+
+## you may set service version if you want to distinguish different configuration version
+spring.eureka.instance.metadata-map.service.version=v1

--- a/linkis-dist/package/conf/linkis-ps-publicservice.properties
+++ b/linkis-dist/package/conf/linkis-ps-publicservice.properties
@@ -50,4 +50,4 @@ spring.spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
 spring.eureka.instance.metadata-map.route=cs_1_dev
 
 ## you may set service version if you want to distinguish different configuration version
-spring.eureka.instance.metadata-map.service.version=v1
+spring.eureka.instance.metadata-map.linkis.conf.version=v1

--- a/linkis-dist/package/conf/linkis-ps-publicservice.properties
+++ b/linkis-dist/package/conf/linkis-ps-publicservice.properties
@@ -48,3 +48,6 @@ spring.spring.main.allow-bean-definition-overriding=true
 spring.spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
 # ps-cs prefix must be started with 'cs_'
 spring.eureka.instance.metadata-map.route=cs_1_dev
+
+## you may set service version if you want to distinguish different configuration version
+spring.eureka.instance.metadata-map.service.version=v1


### PR DESCRIPTION
fix #3989

metadata will act as the following, 
linkis.conf.version :  different configuration version may be changed by end user to record configuration changes
linkis.app.version: recording Linkis software version, together with adding additional install timestamp.

```
<metadata>
<prometheus.path>${prometheus.endpoint}</prometheus.path>
<linkis.conf.version>1.3.0-20230113234012</linkis.conf.version>
<management.port>9001</management.port>
<linkis.app.version>1.3.0-20230113234012</linkis.app.version>
</metadata>
```