### PR TITLE
[ISSUES-4159] fix(linkis-datasource): fix sql error

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/resources/mapper/common/DataSourceTypeMapper.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/resources/mapper/common/DataSourceTypeMapper.xml
@@ -29,11 +29,11 @@
     </resultMap>
 
     <sql id="DataSource_Column">
-        id ,name,description,option,classifier,icon,layers
+        `id` ,`name`,`description`,`option`,`classifier`,`icon`,`layers`
     </sql>
 
     <sql id="DataSource_En_Column">
-        id ,name,COALESCE(description_en, description) as description,option_en as option,classifier_en as classifier,icon,layers
+        `id` ,`name`,COALESCE(description_en, description) as `description`,option_en as `option`,classifier_en as `classifier`,`icon`,`layers`
 
     </sql>
 


### PR DESCRIPTION
### What is the purpose of the change

fix the sql error in get datasource type, because of the keyword without ``

### Related issues/PRs

Related issues: #4159 

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.
