### PR TITLE
Feat metadata query api 1.1 compatible

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/config/DatasourceClientConfig.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/config/DatasourceClientConfig.scala
@@ -24,6 +24,9 @@ object DatasourceClientConfig {
   var METADATA_SERVICE_MODULE: CommonVars[String] =
     CommonVars.apply("linkis.server.mdq.module.name", "metadataQuery")
 
+  var METADATA_OLD_SERVICE_MODULE: CommonVars[String] =
+    CommonVars.apply("linkis.server.mdq.module.name", "metadatamanager")
+
   var DATA_SOURCE_SERVICE_MODULE: CommonVars[String] =
     CommonVars.apply("linkis.server.dsm.module.name", "data-source-manager")
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DataSourceTestConnectAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DataSourceTestConnectAction.scala
@@ -66,7 +66,7 @@ object DataSourceTestConnectAction {
     }
 
     def build(): DataSourceTestConnectAction = {
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
       if (version == null) throw new DataSourceClientBuilderException(VERSION_NEEDED.getErrorDesc)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DeleteDataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/DeleteDataSourceAction.scala
@@ -55,7 +55,7 @@ object DeleteDataSourceAction {
 
     def builder(): DeleteDataSourceAction = {
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/ExpireDataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/ExpireDataSourceAction.scala
@@ -56,7 +56,7 @@ object ExpireDataSourceAction {
     }
 
     def build(): ExpireDataSourceAction = {
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetConnectParamsByDataSourceIdAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetConnectParamsByDataSourceIdAction.scala
@@ -59,7 +59,7 @@ object GetConnectParamsByDataSourceIdAction {
     }
 
     def build(): GetConnectParamsByDataSourceIdAction = {
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetDataSourceVersionsAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetDataSourceVersionsAction.scala
@@ -53,7 +53,7 @@ object GetDataSourceVersionsAction {
     }
 
     def build(): GetDataSourceVersionsAction = {
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetInfoByDataSourceIdAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/GetInfoByDataSourceIdAction.scala
@@ -59,7 +59,7 @@ object GetInfoByDataSourceIdAction {
     }
 
     def build(): GetInfoByDataSourceIdAction = {
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
       if (system == null) throw new DataSourceClientBuilderException(SYSTEM_NEEDED.getErrorDesc)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetColumnsAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetColumnsAction.scala
@@ -17,19 +17,36 @@
 
 package org.apache.linkis.datasource.client.request
 
-import org.apache.linkis.datasource.client.config.DatasourceClientConfig.METADATA_SERVICE_MODULE
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.{
+  METADATA_OLD_SERVICE_MODULE,
+  METADATA_SERVICE_MODULE
+}
 import org.apache.linkis.datasource.client.errorcode.DatasourceClientErrorCodeSummary._
 import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
 import org.apache.linkis.httpclient.request.GetAction
 
-class MetadataGetColumnsAction extends GetAction with DataSourceAction {
+import org.apache.commons.lang3.StringUtils
 
+class MetadataGetColumnsAction extends GetAction with DataSourceAction {
+  private var dataSourceId: Long = _
   private var dataSourceName: String = _
 
   private var database: String = _
   private var table: String = _
 
-  override def suffixURLs: Array[String] = Array(METADATA_SERVICE_MODULE.getValue, "getColumns")
+  override def suffixURLs: Array[String] = if (StringUtils.isNotBlank(dataSourceName)) {
+    Array(METADATA_SERVICE_MODULE.getValue, "getColumns")
+  } else {
+    Array(
+      METADATA_OLD_SERVICE_MODULE.getValue,
+      "columns",
+      dataSourceId.toString,
+      "db",
+      database,
+      "table",
+      table
+    )
+  }
 
   private var user: String = _
 
@@ -42,6 +59,7 @@ object MetadataGetColumnsAction {
   def builder(): Builder = new Builder
 
   class Builder private[MetadataGetColumnsAction] () {
+    private var dataSourceId: Long = _
     private var dataSourceName: String = _
     private var database: String = _
     private var table: String = _
@@ -50,6 +68,20 @@ object MetadataGetColumnsAction {
 
     def setUser(user: String): Builder = {
       this.user = user
+      this
+    }
+
+    /**
+     * get value form dataSourceId is deprecated, suggest to use dataSourceName
+     *
+     * @param dataSourceId
+     *   datasourceId
+     * @return
+     *   builder
+     */
+    @deprecated
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
       this
     }
 
@@ -74,7 +106,7 @@ object MetadataGetColumnsAction {
     }
 
     def build(): MetadataGetColumnsAction = {
-      if (dataSourceName == null) {
+      if (dataSourceName == null && dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCENAME_NEEDED.getErrorDesc)
       }
       if (database == null) throw new DataSourceClientBuilderException(DATABASE_NEEDED.getErrorDesc)
@@ -83,6 +115,7 @@ object MetadataGetColumnsAction {
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)
 
       val metadataGetColumnsAction = new MetadataGetColumnsAction
+      metadataGetColumnsAction.dataSourceId = this.dataSourceId
       metadataGetColumnsAction.dataSourceName = this.dataSourceName
       metadataGetColumnsAction.database = this.database
       metadataGetColumnsAction.table = this.table

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetDatabasesAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetDatabasesAction.scala
@@ -17,16 +17,26 @@
 
 package org.apache.linkis.datasource.client.request
 
-import org.apache.linkis.datasource.client.config.DatasourceClientConfig.METADATA_SERVICE_MODULE
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.{
+  METADATA_OLD_SERVICE_MODULE,
+  METADATA_SERVICE_MODULE
+}
 import org.apache.linkis.datasource.client.errorcode.DatasourceClientErrorCodeSummary._
 import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
 import org.apache.linkis.httpclient.request.GetAction
 
+import org.apache.commons.lang3.StringUtils
+
 class MetadataGetDatabasesAction extends GetAction with DataSourceAction {
 
+  private var dataSourceId: Long = _
   private var dataSourceName: String = _
 
-  override def suffixURLs: Array[String] = Array(METADATA_SERVICE_MODULE.getValue, "getDatabases")
+  override def suffixURLs: Array[String] = if (StringUtils.isNotBlank(dataSourceName)) {
+    Array(METADATA_SERVICE_MODULE.getValue, "getDatabases")
+  } else {
+    Array(METADATA_OLD_SERVICE_MODULE.getValue, "dbs", dataSourceId.toString)
+  }
 
   private var user: String = _
 
@@ -39,12 +49,27 @@ object MetadataGetDatabasesAction {
   def builder(): Builder = new Builder
 
   class Builder private[MetadataGetDatabasesAction] () {
+    private var dataSourceId: Long = _
     private var dataSourceName: String = _
     private var system: String = _
     private var user: String = _
 
     def setUser(user: String): Builder = {
       this.user = user
+      this
+    }
+
+    /**
+     * get value form dataSourceId is deprecated, suggest to use dataSourceName
+     *
+     * @param dataSourceId
+     *   datasourceId
+     * @return
+     *   builder
+     */
+    @deprecated
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
       this
     }
 
@@ -59,13 +84,14 @@ object MetadataGetDatabasesAction {
     }
 
     def build(): MetadataGetDatabasesAction = {
-      if (dataSourceName == null) {
+      if (dataSourceName == null && dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCENAME_NEEDED.getErrorDesc)
       }
       if (system == null) throw new DataSourceClientBuilderException(SYSTEM_NEEDED.getErrorDesc)
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)
 
       val metadataGetDatabasesAction = new MetadataGetDatabasesAction
+      metadataGetDatabasesAction.dataSourceId = this.dataSourceId
       metadataGetDatabasesAction.dataSourceName = this.dataSourceName
       metadataGetDatabasesAction.setParameter("system", system)
       metadataGetDatabasesAction.setUser(user)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetTablesAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/MetadataGetTablesAction.scala
@@ -17,16 +17,27 @@
 
 package org.apache.linkis.datasource.client.request
 
-import org.apache.linkis.datasource.client.config.DatasourceClientConfig.METADATA_SERVICE_MODULE
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.{
+  METADATA_OLD_SERVICE_MODULE,
+  METADATA_SERVICE_MODULE
+}
 import org.apache.linkis.datasource.client.errorcode.DatasourceClientErrorCodeSummary._
 import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
 import org.apache.linkis.httpclient.request.GetAction
 
+import org.apache.commons.lang3.StringUtils
+
 class MetadataGetTablesAction extends GetAction with DataSourceAction {
+
+  private var dataSourceId: Long = _
   private var dataSourceName: String = _
   private var database: String = _
 
-  override def suffixURLs: Array[String] = Array(METADATA_SERVICE_MODULE.getValue, "getTables")
+  override def suffixURLs: Array[String] = if (StringUtils.isNotBlank(dataSourceName)) {
+    Array(METADATA_SERVICE_MODULE.getValue, "getTables")
+  } else {
+    Array(METADATA_OLD_SERVICE_MODULE.getValue, "tables", dataSourceId.toString, "db", database)
+  }
 
   private var user: String = _
 
@@ -39,6 +50,7 @@ object MetadataGetTablesAction {
   def builder(): Builder = new Builder
 
   class Builder private[MetadataGetTablesAction] () {
+    private var dataSourceId: Long = _
     private var dataSourceName: String = _
     private var database: String = _
     private var system: String = _
@@ -49,8 +61,22 @@ object MetadataGetTablesAction {
       this
     }
 
-    def setDataSourceName(dataSourceId: String): Builder = {
-      this.dataSourceName = dataSourceId
+    def setDataSourceName(dataSourceName: String): Builder = {
+      this.dataSourceName = dataSourceName
+      this
+    }
+
+    /**
+     * get value form dataSourceId is deprecated, suggest to use dataSourceName
+     *
+     * @param dataSourceId
+     *   datasourceId
+     * @return
+     *   builder
+     */
+    @deprecated
+    def setDataSourceId(dataSourceId: Long): Builder = {
+      this.dataSourceId = dataSourceId
       this
     }
 
@@ -65,7 +91,7 @@ object MetadataGetTablesAction {
     }
 
     def build(): MetadataGetTablesAction = {
-      if (dataSourceName == null) {
+      if (dataSourceName == null && dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCENAME_NEEDED.getErrorDesc)
       }
       if (database == null) throw new DataSourceClientBuilderException(DATABASE_NEEDED.getErrorDesc)
@@ -73,6 +99,7 @@ object MetadataGetTablesAction {
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)
 
       val metadataGetTablesAction = new MetadataGetTablesAction
+      metadataGetTablesAction.dataSourceId = this.dataSourceId
       metadataGetTablesAction.dataSourceName = this.dataSourceName
       metadataGetTablesAction.database = this.database
       metadataGetTablesAction.setParameter("system", system)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/PublishDataSourceVersionAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/PublishDataSourceVersionAction.scala
@@ -65,11 +65,12 @@ object PublishDataSourceVersionAction {
     }
 
     def build(): PublishDataSourceVersionAction = {
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
-      if (versionId == null)
+      if (versionId == null) {
         throw new DataSourceClientBuilderException(VERSIONID_NEEDED.getErrorDesc)
+      }
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)
 
       val action = new PublishDataSourceVersionAction()

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/UpdateDataSourceAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/UpdateDataSourceAction.scala
@@ -73,7 +73,7 @@ object UpdateDataSourceAction {
     }
 
     def build(): UpdateDataSourceAction = {
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/UpdateDataSourceParameterAction.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/request/UpdateDataSourceParameterAction.scala
@@ -73,7 +73,7 @@ object UpdateDataSourceParameterAction {
     }
 
     def build(): UpdateDataSourceParameterAction = {
-      if (dataSourceId == null) {
+      if (dataSourceId <= 0) {
         throw new DataSourceClientBuilderException(DATASOURCEID_NEEDED.getErrorDesc)
       }
       if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetColumnsResult.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetColumnsResult.scala
@@ -26,7 +26,9 @@ import java.util
 
 import scala.beans.BeanProperty
 
-@DWSHttpMessageResult("/api/rest_j/v\\d+/(metadataQuery|metadatamanager)/(getColumns|columns)(\\S+/db/\\S+/table/\\S+)?")
+@DWSHttpMessageResult(
+  "/api/rest_j/v\\d+/(metadataQuery|metadatamanager)/(getColumns|columns)(\\S+/db/\\S+/table/\\S+)?"
+)
 class MetadataGetColumnsResult extends DWSResult {
   @BeanProperty var columns: util.List[java.util.Map[String, Any]] = _
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetColumnsResult.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetColumnsResult.scala
@@ -26,7 +26,7 @@ import java.util
 
 import scala.beans.BeanProperty
 
-@DWSHttpMessageResult("/api/rest_j/v\\d+/metadataQuery/getColumns")
+@DWSHttpMessageResult("/api/rest_j/v\\d+/(metadataQuery|metadatamanager)/(getColumns|columns)(\\S+/db/\\S+/table/\\S+)?")
 class MetadataGetColumnsResult extends DWSResult {
   @BeanProperty var columns: util.List[java.util.Map[String, Any]] = _
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetDatabasesResult.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetDatabasesResult.scala
@@ -24,7 +24,7 @@ import java.util
 
 import scala.beans.BeanProperty
 
-@DWSHttpMessageResult("/api/rest_j/v\\d+/metadataQuery/getDatabases")
+@DWSHttpMessageResult("/api/rest_j/v\\d+/(metadataQuery|metadatamanager)/(getDatabases|dbs)(\\S+)?")
 class MetadataGetDatabasesResult extends DWSResult {
   @BeanProperty var dbs: util.List[String] = _
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetPartitionsResult.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetPartitionsResult.scala
@@ -26,7 +26,9 @@ import java.util
 
 import scala.beans.BeanProperty
 
-@DWSHttpMessageResult("/api/rest_j/v\\d+/metadataQuery/getPartitions")
+@DWSHttpMessageResult(
+  "/api/rest_j/v\\d+/(metadataQuery|metadatamanager)/(getPartitions|partitions)(\\S+/db/\\S+/table/\\S+)?"
+)
 class MetadataGetPartitionsResult extends DWSResult {
   @BeanProperty var partitions: util.Map[String, Any] = _
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetTablePropsResult.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetTablePropsResult.scala
@@ -24,7 +24,9 @@ import java.util
 
 import scala.beans.BeanProperty
 
-@DWSHttpMessageResult("/api/rest_j/v\\d+/metadataQuery/getTableProp")
+@DWSHttpMessageResult(
+  "/api/rest_j/v\\d+/(metadataQuery|metadatamanager)/(getTableProp|props)(\\S+/db/\\S+/table/\\S+)?"
+)
 class MetadataGetTablePropsResult extends DWSResult {
   @BeanProperty var props: util.Map[String, String] = _
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetTablesResult.scala
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-client/src/main/scala/org/apache/linkis/datasource/client/response/MetadataGetTablesResult.scala
@@ -24,7 +24,9 @@ import java.util
 
 import scala.beans.BeanProperty
 
-@DWSHttpMessageResult("/api/rest_j/v\\d+/metadataQuery/getTables")
+@DWSHttpMessageResult(
+  "/api/rest_j/v\\d+/(metadataQuery|metadatamanager)/(getTables|tables)(\\S+/db/\\S+)?"
+)
 class MetadataGetTablesResult extends DWSResult {
   @BeanProperty var tables: util.List[String] = _
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/resources/mapper/common/DataSouceMapper.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/resources/mapper/common/DataSouceMapper.xml
@@ -89,10 +89,7 @@
         d.`modify_user`, d.`modify_time`, d.`labels`, d.`version_id`,d.`published_version_id`, d.`expire`
     </sql>
     <sql id="data_source_join_type">
-        t
-        .
-        `name`
-        , t.`icon`,
+        t.`name`, t.`icon`,
         d.`id`, d.`datasource_name`, d.`datasource_type_id`, d.`datasource_desc`,
         d.`create_identify`, d.`create_system`, d.`create_user`, d.`parameter`, d.`create_time`,
         d.`modify_user`, d.`modify_time`, d.`version_id`,d.`published_version_id`, d.`labels`, d.`expire`

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/server/src/main/java/org/apache/linkis/metadata/query/server/restful/MetadataCoreRestful.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/server/src/main/java/org/apache/linkis/metadata/query/server/restful/MetadataCoreRestful.java
@@ -192,7 +192,7 @@ public class MetadataCoreRestful {
       MetaPartitionInfo partitionInfo =
           metadataAppService.getPartitionsByDsId(
               dataSourceId, database, table, system, traverse, userName);
-      return Message.ok().data("props", partitionInfo);
+      return Message.ok().data("partitions", partitionInfo).data("props", partitionInfo);
     } catch (Exception e) {
       return errorToResponseMessage(
           "Fail to get partitions[获取表分区信息失败], id:["


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

datasource client compatible with 1.1 api


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
