### PR TITLE
[feat]Support spark3.3+  and spark2.2- compile

### DIFF
--- a/linkis-engineconn-plugins/spark/pom.xml
+++ b/linkis-engineconn-plugins/spark/pom.xml
@@ -188,11 +188,20 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>net.sf.py4j</groupId>
+      <artifactId>py4j</artifactId>
+      <version>0.10.7</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
       <exclusions>
+        <exclusion>
+          <groupId>net.sf.py4j</groupId>
+          <artifactId>py4j</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-common</artifactId>

--- a/linkis-engineconn-plugins/spark/pom.xml
+++ b/linkis-engineconn-plugins/spark/pom.xml
@@ -191,6 +191,7 @@
       <groupId>net.sf.py4j</groupId>
       <artifactId>py4j</artifactId>
       <version>0.10.7</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/HiveSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/HiveSink.scala
@@ -189,16 +189,8 @@ class HiveSink extends DataCalcSink[HiveSinkConfig] with Logging {
                 case dataSourceRegister: DataSourceRegister =>
                   fileFormat = FileFormat.withName(dataSourceRegister.shortName.toUpperCase)
                 case _ =>
-                  val allSubClasses = ClassUtils.reflections.getSubTypesOf(classOf[FileFormat])
-                  breakable {
-                    allSubClasses.asScala
-                      .filter(!ClassUtils.isInterfaceOrAbstract(_))
-                      .foreach(subclass => {
-                        if (subclass.getSimpleName.equals("OrcFileFormat")) {
-                          fileFormat = FileFormat.ORC
-                          break()
-                        }
-                      })
+                  if (hadoopFsRelation.fileFormat.getClass.getSimpleName.equals("OrcFileFormat")) {
+                    fileFormat = FileFormat.ORC
                   }
               }
           }

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/HiveSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/HiveSink.scala
@@ -17,20 +17,17 @@
 
 package org.apache.linkis.engineplugin.spark.datacalc.sink
 
-import org.apache.linkis.common.utils.{ClassUtils, Logging}
+import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcSink
 import org.apache.linkis.engineplugin.spark.datacalc.exception.HiveSinkException
 import org.apache.linkis.engineplugin.spark.errorcode.SparkErrorCodeSummary
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql._
-import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.apache.spark.sql.types.StructField
-
-import scala.collection.JavaConverters.asScalaSetConverter
-import scala.util.control.Breaks.{break, breakable}
 
 class HiveSink extends DataCalcSink[HiveSinkConfig] with Logging {
 
@@ -122,7 +119,9 @@ class HiveSink extends DataCalcSink[HiveSinkConfig] with Logging {
       logFields(sourceFields, targetFields)
       throw new HiveSinkException(
         SparkErrorCodeSummary.DATA_CALC_COLUMN_NUM_NOT_MATCH.getErrorCode,
-        s"$targetTable requires that the data to be inserted have the same number of columns as the target table: target table has ${targetFields.length} column(s) but the inserted data has ${sourceFields.length} column(s)"
+        s"$targetTable requires that the data to be inserted have the same number of columns " +
+          s"as the target table: target table has ${targetFields.length} column(s) " +
+          s"but the inserted data has ${sourceFields.length} column(s)"
       )
     }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/JdbcSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/JdbcSink.scala
@@ -24,9 +24,9 @@ import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcSink
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
-import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, DriverWrapper, JDBCOptions}
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
-import java.sql.{Connection, Driver, DriverManager}
+import java.sql.{Connection, DriverManager}
 
 import scala.collection.JavaConverters._
 

--- a/tool/dependencies/known-dependencies.txt
+++ b/tool/dependencies/known-dependencies.txt
@@ -434,6 +434,7 @@ protostuff-collectionschema-1.6.2.jar
 protostuff-core-1.6.2.jar
 protostuff-runtime-1.6.2.jar
 py4j-0.10.4.jar
+py4j-0.10.7.jar
 quartz-2.3.2.jar
 reactive-streams-1.0.3.jar
 reactor-core-3.3.17.RELEASE.jar


### PR DESCRIPTION
### What is the purpose of the change

1、after spark 3.3.0 JdbcUtils#createConnectionFactory was moved, we can improve code to support spark3.3 +
2、OrcFileFormat may be lack(take before spark2.2.1) ,we can improve code to support lower spark version
3、HiveTableRelation may be lack(take before  spark2.2.1) ,we can improve code to support lower spark version 
4、querytimeout may be lack(take before  spark2.4.0) ,we can improve code to support lower spark version 
5、authtoken may be lack(before spark2.4.0) ,we can improve code to support lower spark version 

### Related issues/PRs

Related issues: #4298 
Related pr: #4301


### Brief change log

1、rewrite `JdbcUtils#createConnectionFactory` in linkis for supporting for higher version spark（method `createConnectionFactory` was moved at https://issues.apache.org/jira/browse/SPARK-38361）
2、use reflectiong to keep `OrcFileFormat` code compatability for higher version spark
3、comment `HiveTableRelation` to keep `HiveTableRelation` code compatability for lower version spark(
further check at
https://github.com/apache/spark/blob/v2.2.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
 https://github.com/apache/spark/blob/v2.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala)
4、decision spark version to keep `querytimeout` code compatability for lower version spark
4、use higher py4jversion to keep `authtoken` code compatability for lower version pyspark

please note: for lower version if compile failed for netty, you may try to compile source code with  -Dnetty.version=4.1.51.Final

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
