### PR TITLE
Fix datasource bug with keyDefinition with defalut value null

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/java/org/apache/linkis/datasourcemanager/core/restful/DataSourceCoreRestfulApi.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/java/org/apache/linkis/datasourcemanager/core/restful/DataSourceCoreRestfulApi.java
@@ -37,6 +37,8 @@ import org.apache.linkis.metadata.query.common.MdmConfiguration;
 import org.apache.linkis.server.Message;
 import org.apache.linkis.server.utils.ModuleUserUtils;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -259,7 +261,8 @@ public class DataSourceCoreRestfulApi {
           keyDefinitionList.forEach(
               keyDefinition -> {
                 String key = keyDefinition.getKey();
-                if (!connectParams.containsKey(key)) {
+                if (StringUtils.isNotBlank(keyDefinition.getDefaultValue())
+                    && !connectParams.containsKey(key)) {
                   connectParams.put(key, keyDefinition.getDefaultValue());
                 }
               });
@@ -315,7 +318,8 @@ public class DataSourceCoreRestfulApi {
           keyDefinitionList.forEach(
               keyDefinition -> {
                 String key = keyDefinition.getKey();
-                if (!connectParams.containsKey(key)) {
+                if (StringUtils.isNotBlank(keyDefinition.getDefaultValue())
+                    && !connectParams.containsKey(key)) {
                   connectParams.put(key, keyDefinition.getDefaultValue());
                 }
               });
@@ -361,10 +365,11 @@ public class DataSourceCoreRestfulApi {
           if (!AuthContext.hasPermission(dataSource, userName)) {
             return Message.error("Don't have query permission for data source [没有数据源的查询权限]");
           }
+
+          List<DataSourceParamKeyDefinition> keyDefinitionList =
+              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId());
           // Decrypt
-          RestfulApiHelper.decryptPasswordKey(
-              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId()),
-              dataSource.getConnectParams());
+          RestfulApiHelper.decryptPasswordKey(keyDefinitionList, dataSource.getConnectParams());
           return Message.ok().data("info", dataSource);
         },
         "Fail to access data source[获取数据源信息失败]");
@@ -396,10 +401,11 @@ public class DataSourceCoreRestfulApi {
           if (!AuthContext.hasPermission(dataSource, userName)) {
             return Message.error("Don't have query permission for data source [没有数据源的查询权限]");
           }
+
+          List<DataSourceParamKeyDefinition> keyDefinitionList =
+              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId());
           // Decrypt
-          RestfulApiHelper.decryptPasswordKey(
-              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId()),
-              dataSource.getConnectParams());
+          RestfulApiHelper.decryptPasswordKey(keyDefinitionList, dataSource.getConnectParams());
 
           return Message.ok().data("info", dataSource);
         },
@@ -432,10 +438,10 @@ public class DataSourceCoreRestfulApi {
           if (!AuthContext.hasPermission(dataSource, userName)) {
             return Message.error("Don't have query permission for data source [没有数据源的查询权限]");
           }
+          List<DataSourceParamKeyDefinition> keyDefinitionList =
+              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId());
           // Decrypt
-          RestfulApiHelper.decryptPasswordKey(
-              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId()),
-              dataSource.getConnectParams());
+          RestfulApiHelper.decryptPasswordKey(keyDefinitionList, dataSource.getConnectParams());
 
           return Message.ok().data("info", dataSource);
         },
@@ -477,10 +483,10 @@ public class DataSourceCoreRestfulApi {
           if (!AuthContext.hasPermission(dataSource, userName)) {
             return Message.error("Don't have query permission for data source [没有数据源的查询权限]");
           }
+          List<DataSourceParamKeyDefinition> keyDefinitionList =
+              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId());
           // Decrypt
-          RestfulApiHelper.decryptPasswordKey(
-              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId()),
-              dataSource.getConnectParams());
+          RestfulApiHelper.decryptPasswordKey(keyDefinitionList, dataSource.getConnectParams());
           return Message.ok().data("info", dataSource);
         },
         "Fail to access data source[获取数据源信息失败]");
@@ -514,14 +520,15 @@ public class DataSourceCoreRestfulApi {
             return Message.error("Don't have query permission for data source [没有数据源的查询权限]");
           }
           List<DatasourceVersion> versions = dataSourceInfoService.getVersionList(dataSourceId);
+
+          List<DataSourceParamKeyDefinition> keyDefinitionList =
+              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId());
           // Decrypt
           if (null != versions) {
             versions.forEach(
                 version -> {
                   RestfulApiHelper.decryptPasswordKey(
-                      dataSourceRelateService.getKeyDefinitionsByType(
-                          dataSource.getDataSourceTypeId()),
-                      version.getConnectParams());
+                      keyDefinitionList, version.getConnectParams());
                 });
           }
           return Message.ok().data("versions", versions);
@@ -665,9 +672,9 @@ public class DataSourceCoreRestfulApi {
             return Message.error("Don't have query permission for data source [没有数据源的查询权限]");
           }
           Map<String, Object> connectParams = dataSource.getConnectParams();
-          RestfulApiHelper.decryptPasswordKey(
-              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId()),
-              connectParams);
+          List<DataSourceParamKeyDefinition> keyDefinitionList =
+              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId());
+          RestfulApiHelper.decryptPasswordKey(keyDefinitionList, connectParams);
           return Message.ok().data("connectParams", connectParams);
         },
         "Fail to connect data source[连接数据源失败]");
@@ -700,9 +707,10 @@ public class DataSourceCoreRestfulApi {
             return Message.error("Don't have query permission for data source [没有数据源的查询权限]");
           }
           Map<String, Object> connectParams = dataSource.getConnectParams();
-          RestfulApiHelper.decryptPasswordKey(
-              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId()),
-              connectParams);
+
+          List<DataSourceParamKeyDefinition> keyDefinitionList =
+              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId());
+          RestfulApiHelper.decryptPasswordKey(keyDefinitionList, connectParams);
           return Message.ok().data("connectParams", connectParams);
         },
         "Fail to connect data source[连接数据源失败]");
@@ -736,12 +744,12 @@ public class DataSourceCoreRestfulApi {
           String dataSourceTypeName = dataSource.getDataSourceType().getName();
           String mdRemoteServiceName = MdmConfiguration.METADATA_SERVICE_APPLICATION.getValue();
           Map<String, Object> connectParams = dataSource.getConnectParams();
-          RestfulApiHelper.decryptPasswordKey(
-              dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId()),
-              connectParams);
+
           // Get definitions
           List<DataSourceParamKeyDefinition> keyDefinitionList =
               dataSourceRelateService.getKeyDefinitionsByType(dataSource.getDataSourceTypeId());
+          RestfulApiHelper.decryptPasswordKey(keyDefinitionList, connectParams);
+
           // For connecting, also need to handle the parameters
           for (DataSourceParamsHook hook : dataSourceParamsHooks) {
             hook.beforePersist(connectParams, keyDefinitionList);
@@ -835,7 +843,8 @@ public class DataSourceCoreRestfulApi {
     keyDefinitionList.forEach(
         keyDefinition -> {
           String key = keyDefinition.getKey();
-          if (!connectParams.containsKey(key)) {
+          if (StringUtils.isNotBlank(keyDefinition.getDefaultValue())
+              && !connectParams.containsKey(key)) {
             connectParams.put(key, keyDefinition.getDefaultValue());
           }
         });

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/server/src/main/java/org/apache/linkis/metadata/query/server/service/impl/MetadataQueryServiceImpl.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/server/src/main/java/org/apache/linkis/metadata/query/server/service/impl/MetadataQueryServiceImpl.java
@@ -326,7 +326,8 @@ public class MetadataQueryServiceImpl implements MetadataQueryService {
     if (rpcResult instanceof DsInfoResponse) {
       DsInfoResponse response = (DsInfoResponse) rpcResult;
       if (!response.status()) {
-        throw new ErrorException(-1, "Error in Data Source Manager Server[数据源服务出错]");
+        throw new ErrorException(
+            -1, "Error in Data Source Manager Server[数据源服务出错] " + response.errorMsg());
       }
       boolean hasPermission =
           (AuthContext.isAdministrator(userName)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

Fix datasource bug with keyDefinition with defalut value null


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
