### PR TITLE
[fix bug] The s3a file cannot be written because FileSystem is closed prematurely

### DIFF
--- a/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/StorageResultSetWriter.scala
+++ b/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/StorageResultSetWriter.scala
@@ -187,11 +187,11 @@ class StorageResultSetWriter[K <: MetaData, V <: Record](
       }
     }
     Utils.tryFinally(if (outputStream != null) flush()) {
-      closeFs
       if (outputStream != null) {
         IOUtils.closeQuietly(outputStream)
         outputStream = null
       }
+      closeFs
     }
   }
 


### PR DESCRIPTION

[The s3a file cannot be written because FileSystem is closed prematurely](https://github.com/apache/linkis/blob/dev-1.4.0/linkis-commons/linkis-storage/src/main/scala/org/apache/linkis/storage/resultset/StorageResultSetWriter.scala)
```scala
    Utils.tryFinally(if (outputStream != null) flush()) {
      closeFs
      if (outputStream != null) {
        IOUtils.closeQuietly(outputStream)
        outputStream = null
      }
    }
```

Change to
```scala
    Utils.tryFinally(if (outputStream != null) flush()) {
      if (outputStream != null) {
        IOUtils.closeQuietly(outputStream)
        outputStream = null
      }
      closeFs
    }
```