### PR TITLE
[Bug] Engine type label support map value

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-label-common/src/main/java/org/apache/linkis/manager/label/entity/engine/EngineTypeLabel.java
+++ b/linkis-computation-governance/linkis-manager/linkis-label-common/src/main/java/org/apache/linkis/manager/label/entity/engine/EngineTypeLabel.java
@@ -23,6 +23,7 @@ import org.apache.linkis.manager.label.entity.EngineNodeLabel;
 import org.apache.linkis.manager.label.entity.Feature;
 import org.apache.linkis.manager.label.entity.GenericLabel;
 import org.apache.linkis.manager.label.entity.annon.ValueSerialNum;
+import org.apache.linkis.manager.label.utils.LabelUtils;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -77,16 +78,27 @@ public class EngineTypeLabel extends GenericLabel implements EngineNodeLabel, EM
 
   @Override
   protected void setStringValue(String stringValue) {
-    String version;
-    String engineType = stringValue.split("-")[0];
+    if (StringUtils.isNotBlank(stringValue)) {
+      HashMap<String, String> valueMap = LabelUtils.Jackson.fromJson(stringValue, HashMap.class);
+      if (valueMap == null) {
+        String version;
+        String engineType = stringValue.split("-")[0];
 
-    if (engineType.equals("*")) {
-      version = stringValue.replaceFirst("[" + engineType + "]-", "");
+        if (engineType.equals("*")) {
+          version = stringValue.replaceFirst("[" + engineType + "]-", "");
+        } else {
+          version = stringValue.replaceFirst(engineType + "-", "");
+        }
+
+        setEngineType(engineType);
+        setVersion(version);
+      } else {
+        setEngineType(valueMap.get("engineType"));
+        setVersion(valueMap.get("version"));
+      }
     } else {
-      version = stringValue.replaceFirst(engineType + "-", "");
+      setEngineType("*");
+      setVersion("*");
     }
-
-    setEngineType(engineType);
-    setVersion(version);
   }
 }

--- a/linkis-computation-governance/linkis-manager/linkis-label-common/src/test/java/org/apache/linkis/manager/label/entity/engine/EngineTypeLabelTest.java
+++ b/linkis-computation-governance/linkis-manager/linkis-label-common/src/test/java/org/apache/linkis/manager/label/entity/engine/EngineTypeLabelTest.java
@@ -28,20 +28,38 @@ public class EngineTypeLabelTest {
 
   @Test
   public void testSetStringValue() {
-    String engineType = "hive";
-    String version = "1.1.0-cdh5.12.0";
-
-    String engineType1 = "*";
-    String version1 = "*";
-
     LabelBuilderFactory labelBuilderFactory = LabelBuilderFactoryContext.getLabelBuilderFactory();
     EngineTypeLabel engineTypeLabel = labelBuilderFactory.createLabel(EngineTypeLabel.class);
-    engineTypeLabel.setStringValue(engineType + "-" + version);
-    Assertions.assertEquals(engineTypeLabel.getEngineType(), engineType);
-    Assertions.assertEquals(engineTypeLabel.getVersion(), version);
 
-    engineTypeLabel.setStringValue(engineType1 + "-" + version1);
-    Assertions.assertEquals(engineTypeLabel.getEngineType(), engineType1);
-    Assertions.assertEquals(engineTypeLabel.getVersion(), version1);
+    // str value
+    String hiveEngineType = "hive";
+    String hiveVersion = "1.1.0-cdh5.12.0";
+    engineTypeLabel.setStringValue(hiveEngineType + "-" + hiveVersion);
+    Assertions.assertEquals(engineTypeLabel.getEngineType(), hiveEngineType);
+    Assertions.assertEquals(engineTypeLabel.getVersion(), hiveVersion);
+
+    // any value
+    String anyEngineType = "*";
+    String anyVersion = "*";
+    engineTypeLabel.setStringValue(anyEngineType + "-" + anyVersion);
+    Assertions.assertEquals(engineTypeLabel.getEngineType(), anyEngineType);
+    Assertions.assertEquals(engineTypeLabel.getVersion(), anyVersion);
+
+    // map value
+    String mapStringValue = "{\"engineType\":\"shell\",\"version\":\"1\"}";
+    engineTypeLabel.setStringValue(mapStringValue);
+    Assertions.assertEquals(engineTypeLabel.getEngineType(), "shell");
+    Assertions.assertEquals(engineTypeLabel.getVersion(), "1");
+
+    // empty value will treat as *
+    String emptyStringValue = "";
+    engineTypeLabel.setStringValue(emptyStringValue);
+    Assertions.assertEquals(engineTypeLabel.getEngineType(), "*");
+    Assertions.assertEquals(engineTypeLabel.getVersion(), "*");
+
+    // null value will treat as *
+    engineTypeLabel.setStringValue(null);
+    Assertions.assertEquals(engineTypeLabel.getEngineType(), "*");
+    Assertions.assertEquals(engineTypeLabel.getVersion(), "*");
   }
 }


### PR DESCRIPTION
### What is the purpose of the change

Engine type label should accept stringvalue like `"{\"engineType\":\"shell\",\"version\":\"1\"}"`
not only support stringvalue like `"hive-1.1.0-cdh5.12.0"`

### Related issues/PRs

Related issues: #4410 
Related pr:#4409


### Brief change log

- Engine type label should accept map string value


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
