### PR TITLE
[Bug]: fix the bug that can not found  /opt/tmp/DISCLAIMER directory in dock…

### DIFF
--- a/linkis-dist/docker/linkis.Dockerfile
+++ b/linkis-dist/docker/linkis.Dockerfile
@@ -79,7 +79,6 @@ ADD apache-linkis-${LINKIS_VERSION}-bin /opt/tmp/
 RUN mv /opt/tmp/linkis-package/* ${LINKIS_HOME}/ \
     && mv /opt/tmp/LICENSE  ${LINKIS_HOME}/ \
     && mv /opt/tmp/NOTICE   ${LINKIS_HOME}/ \
-    && mv /opt/tmp/DISCLAIMER ${LINKIS_HOME}/ \
     && mv /opt/tmp/README.md  ${LINKIS_HOME}/ \
     && mv /opt/tmp/README_CN.md  ${LINKIS_HOME}/ \
     && rm -rf /opt/tmp


### PR DESCRIPTION
### What is the purpose of the change

fix the bug that can not found  /opt/tmp/DISCLAIMER directory in docker image

### Related issues/PRs

Related issues: #4464 


### Brief change log

- modify linkis/linkis-dist/docker/linkis.Dockerfile for fix bug


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [x] **If this is a code change**: I have written unit tests to fully verify the new behavior.

