### PR TITLE
Fixed the linkis-metadata-query-service-jdbc bug

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/ClickhouseMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/ClickhouseMetaService.java
@@ -24,6 +24,8 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.clickhouse.SqlConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
@@ -53,8 +55,10 @@ public class ClickhouseMetaService extends AbstractDbMetaService<SqlConnection> 
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/Db2MetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/Db2MetaService.java
@@ -24,6 +24,8 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.db2.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
@@ -54,8 +56,10 @@ public class Db2MetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/DmMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/DmMetaService.java
@@ -24,6 +24,8 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.dm.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
@@ -51,8 +53,10 @@ public class DmMetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/DorisMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/DorisMetaService.java
@@ -24,6 +24,8 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.mysql.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
@@ -53,8 +55,10 @@ public class DorisMetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/GreenplumMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/GreenplumMetaService.java
@@ -24,6 +24,7 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.greenplum.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 
 import java.sql.SQLException;
@@ -58,8 +59,10 @@ public class GreenplumMetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/KingbaseMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/KingbaseMetaService.java
@@ -24,6 +24,8 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.kingbase.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
@@ -52,8 +54,10 @@ public class KingbaseMetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/OracleMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/OracleMetaService.java
@@ -24,6 +24,8 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.oracle.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
@@ -59,8 +61,10 @@ public class OracleMetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/PostgresqlMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/PostgresqlMetaService.java
@@ -24,6 +24,7 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.postgres.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 
 import java.sql.SQLException;
@@ -59,8 +60,10 @@ public class PostgresqlMetaService extends AbstractDbMetaService<SqlConnection> 
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/SqlserverMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/SqlserverMetaService.java
@@ -24,6 +24,8 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.sqlserver.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
@@ -48,8 +50,10 @@ public class SqlserverMetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/StarrocksMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/StarrocksMetaService.java
@@ -24,6 +24,8 @@ import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.mysql.SqlConnection;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
@@ -53,8 +55,10 @@ public class StarrocksMetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/TidbMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/TidbMetaService.java
@@ -17,13 +17,14 @@
 
 package org.apache.linkis.metadata.query.service;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.linkis.datasourcemanager.common.util.json.Json;
 import org.apache.linkis.metadata.query.common.domain.MetaColumnInfo;
 import org.apache.linkis.metadata.query.common.service.AbstractDbMetaService;
 import org.apache.linkis.metadata.query.common.service.MetadataConnection;
 import org.apache.linkis.metadata.query.service.conf.SqlParamsMapper;
 import org.apache.linkis.metadata.query.service.mysql.SqlConnection;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.stereotype.Component;
 

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/TidbMetaService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/TidbMetaService.java
@@ -17,6 +17,7 @@
 
 package org.apache.linkis.metadata.query.service;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.linkis.datasourcemanager.common.util.json.Json;
 import org.apache.linkis.metadata.query.common.domain.MetaColumnInfo;
 import org.apache.linkis.metadata.query.common.service.AbstractDbMetaService;
@@ -53,8 +54,10 @@ public class TidbMetaService extends AbstractDbMetaService<SqlConnection> {
     Object sqlParamObj = params.get(SqlParamsMapper.PARAM_SQL_EXTRA_PARAMS.getValue());
     if (null != sqlParamObj) {
       if (!(sqlParamObj instanceof Map)) {
-        extraParams =
-            Json.fromJson(String.valueOf(sqlParamObj), Map.class, String.class, Object.class);
+        String paramStr = String.valueOf(sqlParamObj);
+        if (StringUtils.isNotBlank(paramStr)) {
+          extraParams = Json.fromJson(paramStr, Map.class, String.class, Object.class);
+        }
       } else {
         extraParams = (Map<String, Object>) sqlParamObj;
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/125547374/235333208-71820f45-09ca-4b6c-9a28-990154387055.png)
![image](https://user-images.githubusercontent.com/125547374/235333211-9a441d24-06f9-496d-ad89-46d925913fcb.png)

Connection params is empty. NullPointerException
