### PR TITLE
Dependabot/maven/linkis public enhancements/linkis datasource/linkis metadata query/service/jdbc/com.clickhouse clickhouse jdbc 0.4.6

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <postgresql.version>42.3.8</postgresql.version>
-    <clickhouse.version>0.3.2-patch11</clickhouse.version>
+    <clickhouse.version>0.4.6</clickhouse.version>
   </properties>
 
   <dependencies>

--- a/tool/dependencies/known-dependencies.txt
+++ b/tool/dependencies/known-dependencies.txt
@@ -51,7 +51,7 @@ chill-java-0.7.6.jar
 chill_2.11-0.7.6.jar
 classgraph-4.1.7.jar
 classmate-1.5.1.jar
-clickhouse-jdbc-0.3.2-patch11.jar
+clickhouse-jdbc-0.4.6.jar
 commons-beanutils-1.9.4.jar
 commons-cli-1.2.jar
 commons-cli-1.3.1.jar
@@ -93,7 +93,6 @@ derby-10.14.2.0.jar
 disruptor-3.3.0.jar
 dropwizard-metrics-hadoop-metrics2-reporter-0.1.2.jar
 druid-1.1.22.jar
-dss-gateway-support-1.1.1.jar
 eigenbase-properties-1.1.5.jar
 elasticsearch-rest-client-6.8.15.jar
 elasticsearch-rest-client-7.6.2.jar
@@ -439,7 +438,6 @@ protostuff-collectionschema-1.6.2.jar
 protostuff-core-1.6.2.jar
 protostuff-runtime-1.6.2.jar
 py4j-0.10.4.jar
-py4j-0.10.7.jar
 quartz-2.3.2.jar
 reactive-streams-1.0.3.jar
 reactor-core-3.3.17.RELEASE.jar


### PR DESCRIPTION
Bumps clickhouse-jdbc from 0.3.2-patch11 to 0.4.6.
#4536 