### PR TITLE
[Feature][linkis-computation-client] Provide a method which can get CreateEngineResult when submit a [once] job

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
@@ -23,10 +23,10 @@ import org.apache.linkis.computation.client.LinkisJobMetrics
 import org.apache.linkis.computation.client.job.AbstractSubmittableLinkisJob
 import org.apache.linkis.computation.client.once.{LinkisManagerClient, OnceJob, SubmittableOnceJob}
 import org.apache.linkis.computation.client.once.action.CreateEngineConnAction
+import org.apache.linkis.computation.client.once.result.CreateEngineConnResult
 import org.apache.linkis.computation.client.operator.OnceJobOperator
 
 import java.util.Locale
-
 import scala.concurrent.duration.Duration
 
 trait SimpleOnceJob extends OnceJob {
@@ -104,13 +104,15 @@ class SubmittableSimpleOnceJob(
     with AbstractSubmittableLinkisJob {
 
   private var ecmServiceInstance: ServiceInstance = _
+  private var createEngineConnResult: CreateEngineConnResult = _
 
   def getECMServiceInstance: ServiceInstance = ecmServiceInstance
+  def getCreateEngineConnResult: CreateEngineConnResult = createEngineConnResult
 
   override protected def doSubmit(): Unit = {
     logger.info(s"Ready to create a engineConn: ${createEngineConnAction.getRequestPayload}.")
-    val nodeInfo = linkisManagerClient.createEngineConn(createEngineConnAction)
-    lastNodeInfo = nodeInfo.getNodeInfo
+    createEngineConnResult = linkisManagerClient.createEngineConn(createEngineConnAction)
+    lastNodeInfo = createEngineConnResult.getNodeInfo
     serviceInstance = getServiceInstance(lastNodeInfo)
     ticketId = getTicketId(lastNodeInfo)
     ecmServiceInstance = getECMServiceInstance(lastNodeInfo)

--- a/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
+++ b/linkis-computation-governance/linkis-client/linkis-computation-client/src/main/scala/org/apache/linkis/computation/client/once/simple/SimpleOnceJob.scala
@@ -27,6 +27,7 @@ import org.apache.linkis.computation.client.once.result.CreateEngineConnResult
 import org.apache.linkis.computation.client.operator.OnceJobOperator
 
 import java.util.Locale
+
 import scala.concurrent.duration.Duration
 
 trait SimpleOnceJob extends OnceJob {


### PR DESCRIPTION
### What is the purpose of the change

Provide a method which can get CreateEngineResult when submit a [once] job

### Related issues/PRs

Related issues: #4582

