### PR TITLE
fix-4598: fix jersey-apache-client4 missing 

### DIFF
--- a/linkis-engineconn-plugins/spark/pom.xml
+++ b/linkis-engineconn-plugins/spark/pom.xml
@@ -294,6 +294,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.sun.jersey.contribs</groupId>
+      <artifactId>jersey-apache-client4</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-auth</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
fix spark task error java.lang.NoClassDefFoundError: com/sun/jersey/client/apache4/ApacheHttpClient4 #4598