### PR TITLE
remove v prefix for impala and add default compile mode

### DIFF
--- a/linkis-engineconn-plugins/impala/src/main/assembly/distribution.xml
+++ b/linkis-engineconn-plugins/impala/src/main/assembly/distribution.xml
@@ -30,7 +30,7 @@
         <dependencySet>
             <!-- Enable access to all projects in the current multimodule build! <useAllReactorProjects>true</useAllReactorProjects> -->
             <!-- Now, select which projects to include in this module-set. -->
-            <outputDirectory>/dist/v${impala.version}/lib</outputDirectory>
+            <outputDirectory>/dist/${impala.version}/lib</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <unpack>false</unpack>
@@ -48,7 +48,7 @@
                 <include>log4j2.xml</include>
             </includes>
             <fileMode>0777</fileMode>
-            <outputDirectory>/dist/v${impala.version}/conf</outputDirectory>
+            <outputDirectory>/dist/${impala.version}/conf</outputDirectory>
             <lineEnding>unix</lineEnding>
         </fileSet>
 

--- a/linkis-engineconn-plugins/pom.xml
+++ b/linkis-engineconn-plugins/pom.xml
@@ -41,7 +41,14 @@
     <module>trino</module>
     <module>elasticsearch</module>
     <module>seatunnel</module>
-    <!--<module>impala</module>-->
   </modules>
+  <profiles>
+    <profile>
+      <id>compile-impala</id>
+      <modules>
+        <module>impala</module>
+      </modules>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
1.remove v prefix for impala
2.add impala is not compiled by default
To compile impala ec, perform the following operations
 mvn package -P compile-impala