### PR TITLE
[Fix Bug]Fix spark mongo etl task execution failed

### DIFF
--- a/linkis-engineconn-plugins/spark/scala-2.12/pom.xml
+++ b/linkis-engineconn-plugins/spark/scala-2.12/pom.xml
@@ -135,6 +135,38 @@
       <groupId>org.mongodb.spark</groupId>
       <artifactId>mongo-spark-connector_${scala.binary.version}</artifactId>
       <version>3.0.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mongodb</groupId>
+          <artifactId>bson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mongodb</groupId>
+          <artifactId>mongodb-driver-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.mongodb</groupId>
+          <artifactId>mongodb-driver-sync</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-sync</artifactId>
+      <version>${mongodb.driver.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-core</artifactId>
+      <version>${mongodb.driver.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>bson</artifactId>
+      <version>${mongodb.driver.version}</version>
     </dependency>
 
     <dependency>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/mongodb/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/mongodb/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>3.12.8</version>
+      <version>${mongodb.driver.version}</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
     <mysql.connector.scope>test</mysql.connector.scope>
     <postgresql.connector.version>42.2.20</postgresql.connector.version>
     <druid.version>1.2.16</druid.version>
+    <mongodb.driver.version>3.12.8</mongodb.driver.version>
 
     <!-- utils -->
     <guava.version>30.0-jre</guava.version>


### PR DESCRIPTION
![image](https://github.com/apache/linkis/assets/125547374/2f061fa6-4d6e-4d3d-be47-cd2074675f66)

The mongo version of the Mongo-Spark-connector is the same as the Mongo-Java-driver version