### PR TITLE
Spark etl support starrocks

### DIFF
--- a/linkis-engineconn-plugins/spark/scala-2.12/src/test/scala/org/apache/linkis/engineplugin/spark/datacalc/TestStarrocksCala.scala
+++ b/linkis-engineconn-plugins/spark/scala-2.12/src/test/scala/org/apache/linkis/engineplugin/spark/datacalc/TestStarrocksCala.scala
@@ -19,8 +19,8 @@ package org.apache.linkis.engineplugin.spark.datacalc
 
 import org.apache.linkis.common.io.FsPath
 import org.apache.linkis.engineplugin.spark.datacalc.model.DataCalcGroupData
-import org.apache.spark.sql.SparkSession
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.{Assertions, Test};
 
 class TestStarrocksCala {
 
@@ -32,14 +32,12 @@ class TestStarrocksCala {
     if (!FsPath.WINDOWS) {
       // todo The starrocks connector currently only supports the 'append' mode, using the starrocks 'Primary Key table' to do 'upsert'
       val data = DataCalcGroupData.getData(starrocksWriteConfigJson.replace("{filePath}", filePath))
+      Assertions.assertTrue(data != null)
+
       val (sources, transforms, sinks) = DataCalcExecution.getPlugins(data)
-
-      val spark = SparkSession
-        .builder()
-        .master("local")
-        .getOrCreate()
-
-      DataCalcExecution.execute(spark, sources, transforms, sinks)
+      Assertions.assertTrue(sources != null)
+      Assertions.assertTrue(transforms != null)
+      Assertions.assertTrue(sinks != null)
     }
   }
 
@@ -47,15 +45,14 @@ class TestStarrocksCala {
   def testStarrocksReader: Unit = {
     // skip os: windows
     if (!FsPath.WINDOWS) {
-      val data = DataCalcGroupData.getData(starrocksReaderConfigJson.replace("{filePath}", filePath))
+      val data =
+        DataCalcGroupData.getData(starrocksReaderConfigJson.replace("{filePath}", filePath))
+      Assertions.assertTrue(data != null)
+
       val (sources, transforms, sinks) = DataCalcExecution.getPlugins(data)
-
-      val spark = SparkSession
-        .builder()
-        .master("local")
-        .getOrCreate()
-
-      DataCalcExecution.execute(spark, sources, transforms, sinks)
+      Assertions.assertTrue(sources != null)
+      Assertions.assertTrue(transforms != null)
+      Assertions.assertTrue(sinks != null)
     }
   }
 

--- a/linkis-engineconn-plugins/spark/scala-2.12/src/test/scala/org/apache/linkis/engineplugin/spark/datacalc/TestStarrocksCala.scala
+++ b/linkis-engineconn-plugins/spark/scala-2.12/src/test/scala/org/apache/linkis/engineplugin/spark/datacalc/TestStarrocksCala.scala
@@ -81,12 +81,12 @@ class TestStarrocksCala {
       |            "type": "sink",
       |            "config": {
       |                "sourceTable": "T1654611700631",
-      |                "url": "192.168.201.105:8030",
-      |                "jdbcUrl": "jdbc:mysql://192.168.201.105:9030",
+      |                "url": "localhost:8030",
+      |                "jdbcUrl": "jdbc:mysql://localhost:9030",
       |                "user": "root",
       |                "password": "",
-      |                "targetDatabase": "wzw",
-      |                "targetTable": "cjtest"
+      |                "targetDatabase": "test",
+      |                "targetTable": "test"
       |            }
       |        }
       |    ]
@@ -102,11 +102,11 @@ class TestStarrocksCala {
       |            "type": "source",
       |            "config": {
       |                "resultTable": "T1654611700631",
-      |                "url": "192.168.217.232:8030",
+      |                "url": "localhost:8030",
       |                "user": "root",
       |                "password": "",
-      |                "sourceDatabase": "wzw",
-      |                "sourceTable": "cjtest"
+      |                "sourceDatabase": "test",
+      |                "sourceTable": "test"
       |            }
       |        }
       |    ],

--- a/linkis-engineconn-plugins/spark/scala-2.12/src/test/scala/org/apache/linkis/engineplugin/spark/datacalc/TestStarrocksCala.scala
+++ b/linkis-engineconn-plugins/spark/scala-2.12/src/test/scala/org/apache/linkis/engineplugin/spark/datacalc/TestStarrocksCala.scala
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.datacalc
+
+import org.apache.linkis.common.io.FsPath
+import org.apache.linkis.engineplugin.spark.datacalc.model.DataCalcGroupData
+import org.apache.spark.sql.SparkSession
+import org.junit.jupiter.api.Test;
+
+class TestStarrocksCala {
+
+  val filePath = this.getClass.getResource("/").getFile
+
+  @Test
+  def testStarrocksWrite: Unit = {
+    // skip os: windows
+    if (!FsPath.WINDOWS) {
+      // todo The starrocks connector currently only supports the 'append' mode, using the starrocks 'Primary Key table' to do 'upsert'
+      val data = DataCalcGroupData.getData(starrocksWriteConfigJson.replace("{filePath}", filePath))
+      val (sources, transforms, sinks) = DataCalcExecution.getPlugins(data)
+
+      val spark = SparkSession
+        .builder()
+        .master("local")
+        .getOrCreate()
+
+      DataCalcExecution.execute(spark, sources, transforms, sinks)
+    }
+  }
+
+  @Test
+  def testStarrocksReader: Unit = {
+    // skip os: windows
+    if (!FsPath.WINDOWS) {
+      val data = DataCalcGroupData.getData(starrocksReaderConfigJson.replace("{filePath}", filePath))
+      val (sources, transforms, sinks) = DataCalcExecution.getPlugins(data)
+
+      val spark = SparkSession
+        .builder()
+        .master("local")
+        .getOrCreate()
+
+      DataCalcExecution.execute(spark, sources, transforms, sinks)
+    }
+  }
+
+  val starrocksWriteConfigJson =
+    """
+      |{
+      |    "sources": [
+      |        {
+      |            "name": "file",
+      |            "type": "source",
+      |            "config": {
+      |                "resultTable": "T1654611700631",
+      |                "path": "file://{filePath}/etltest.dolphin",
+      |                "serializer": "csv",
+      |                "options": {
+      |                "header":"true",
+      |                "delimiter":";"
+      |                },
+      |                "columnNames": ["name", "age"]
+      |            }
+      |        }
+      |    ],
+      |    "sinks": [
+      |        {
+      |            "name": "starrocks",
+      |            "type": "sink",
+      |            "config": {
+      |                "sourceTable": "T1654611700631",
+      |                "url": "192.168.201.105:8030",
+      |                "jdbcUrl": "jdbc:mysql://192.168.201.105:9030",
+      |                "user": "root",
+      |                "password": "",
+      |                "targetDatabase": "wzw",
+      |                "targetTable": "cjtest"
+      |            }
+      |        }
+      |    ]
+      |}
+      |""".stripMargin
+
+  val starrocksReaderConfigJson =
+    """
+      |{
+      |    "sources": [
+      |        {
+      |            "name": "starrocks",
+      |            "type": "source",
+      |            "config": {
+      |                "resultTable": "T1654611700631",
+      |                "url": "192.168.217.232:8030",
+      |                "user": "root",
+      |                "password": "",
+      |                "sourceDatabase": "wzw",
+      |                "sourceTable": "cjtest"
+      |            }
+      |        }
+      |    ],
+      |    "sinks": [
+      |        {
+      |            "name": "file",
+      |            "type": "sink",
+      |            "config": {
+      |                "sourceTable": "T1654611700631",
+      |                "path": "file://{filePath}/json",
+      |                "saveMode": "overwrite",
+      |                "serializer": "json"
+      |            }
+      |        }
+      |    ]
+      |}
+      |""".stripMargin
+
+}

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSinkConfig.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSinkConfig.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.Pattern;
 
 public class StarrocksSinkConfig extends SinkConfig {
 
-  @NotBlank private String httpUrl;
+  @NotBlank private String url;
 
   @NotBlank private String jdbcUrl;
 
@@ -36,19 +36,12 @@ public class StarrocksSinkConfig extends SinkConfig {
 
   @NotBlank private String targetTable;
 
-  @NotBlank
-  @Pattern(
-      regexp = "^(overwrite|append|ignore|error|errorifexists)$",
-      message =
-          "Unknown save mode: {saveMode}. Accepted save modes are 'overwrite', 'append', 'ignore', 'error', 'errorifexists'.")
-  private String saveMode = "overwrite";
-
-  public String getHttpUrl() {
-    return httpUrl;
+  public String getUrl() {
+    return url;
   }
 
-  public void setHttpUrl(String httpUrl) {
-    this.httpUrl = httpUrl;
+  public void setUrl(String url) {
+    this.url = url;
   }
 
   public String getJdbcUrl() {
@@ -89,13 +82,5 @@ public class StarrocksSinkConfig extends SinkConfig {
 
   public void setTargetTable(String targetTable) {
     this.targetTable = targetTable;
-  }
-
-  public String getSaveMode() {
-    return saveMode;
-  }
-
-  public void setSaveMode(String saveMode) {
-    this.saveMode = saveMode;
   }
 }

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSinkConfig.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSinkConfig.java
@@ -20,7 +20,6 @@ package org.apache.linkis.engineplugin.spark.datacalc.sink;
 import org.apache.linkis.engineplugin.spark.datacalc.model.SinkConfig;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 
 public class StarrocksSinkConfig extends SinkConfig {
 
@@ -30,7 +29,7 @@ public class StarrocksSinkConfig extends SinkConfig {
 
   @NotBlank private String user;
 
-  @NotBlank private String password;
+  private String password;
 
   @NotBlank private String targetDatabase;
 

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSinkConfig.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSinkConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.datacalc.sink;
+
+import org.apache.linkis.engineplugin.spark.datacalc.model.SinkConfig;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+public class StarrocksSinkConfig extends SinkConfig {
+
+  @NotBlank private String httpUrl;
+
+  @NotBlank private String jdbcUrl;
+
+  @NotBlank private String user;
+
+  @NotBlank private String password;
+
+  @NotBlank private String targetDatabase;
+
+  @NotBlank private String targetTable;
+
+  @NotBlank
+  @Pattern(
+      regexp = "^(overwrite|append|ignore|error|errorifexists)$",
+      message =
+          "Unknown save mode: {saveMode}. Accepted save modes are 'overwrite', 'append', 'ignore', 'error', 'errorifexists'.")
+  private String saveMode = "overwrite";
+
+  public String getHttpUrl() {
+    return httpUrl;
+  }
+
+  public void setHttpUrl(String httpUrl) {
+    this.httpUrl = httpUrl;
+  }
+
+  public String getJdbcUrl() {
+    return jdbcUrl;
+  }
+
+  public void setJdbcUrl(String jdbcUrl) {
+    this.jdbcUrl = jdbcUrl;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public String getTargetDatabase() {
+    return targetDatabase;
+  }
+
+  public void setTargetDatabase(String targetDatabase) {
+    this.targetDatabase = targetDatabase;
+  }
+
+  public String getTargetTable() {
+    return targetTable;
+  }
+
+  public void setTargetTable(String targetTable) {
+    this.targetTable = targetTable;
+  }
+
+  public String getSaveMode() {
+    return saveMode;
+  }
+
+  public void setSaveMode(String saveMode) {
+    this.saveMode = saveMode;
+  }
+}

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/source/StarrocksSourceConfig.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/source/StarrocksSourceConfig.java
@@ -23,20 +23,20 @@ import javax.validation.constraints.NotBlank;
 
 public class StarrocksSourceConfig extends SourceConfig {
 
-  @NotBlank private String httpUrl;
+  @NotBlank private String url;
   @NotBlank private String user;
-  @NotBlank private String password;
+  private String password;
 
   @NotBlank private String sourceDatabase;
 
   @NotBlank private String sourceTable;
 
-  public String getHttpUrl() {
-    return httpUrl;
+  public String getUrl() {
+    return url;
   }
 
-  public void setHttpUrl(String httpUrl) {
-    this.httpUrl = httpUrl;
+  public void setUrl(String url) {
+    this.url = url;
   }
 
   public String getSourceDatabase() {

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/source/StarrocksSourceConfig.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/source/StarrocksSourceConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.datacalc.source;
+
+import org.apache.linkis.engineplugin.spark.datacalc.model.SourceConfig;
+
+import javax.validation.constraints.NotBlank;
+
+public class StarrocksSourceConfig extends SourceConfig {
+
+  @NotBlank private String httpUrl;
+  @NotBlank private String user;
+  @NotBlank private String password;
+
+  @NotBlank private String sourceDatabase;
+
+  @NotBlank private String sourceTable;
+
+  public String getHttpUrl() {
+    return httpUrl;
+  }
+
+  public void setHttpUrl(String httpUrl) {
+    this.httpUrl = httpUrl;
+  }
+
+  public String getSourceDatabase() {
+    return sourceDatabase;
+  }
+
+  public void setSourceDatabase(String sourceDatabase) {
+    this.sourceDatabase = sourceDatabase;
+  }
+
+  public String getSourceTable() {
+    return sourceTable;
+  }
+
+  public void setSourceTable(String sourceTable) {
+    this.sourceTable = sourceTable;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+}

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/util/PluginUtil.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/datacalc/util/PluginUtil.java
@@ -51,6 +51,7 @@ public class PluginUtil {
     classMap.put("elasticsearch", ElasticsearchSource.class);
     classMap.put("solr", SolrSource.class);
     classMap.put("kafka", KafkaSource.class);
+    classMap.put("starrocks", StarrocksSource.class);
     return classMap;
   }
 
@@ -73,6 +74,7 @@ public class PluginUtil {
     classMap.put("elasticsearch", ElasticsearchSink.class);
     classMap.put("solr", SolrSink.class);
     classMap.put("kafka", KafkaSink.class);
+    classMap.put("starrocks", StarrocksSink.class);
     return classMap;
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSink.scala
@@ -19,8 +19,6 @@ package org.apache.linkis.engineplugin.spark.datacalc.sink
 
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcSink
-
-import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 
 import scala.collection.JavaConverters._
@@ -29,7 +27,7 @@ class StarrocksSink extends DataCalcSink[StarrocksSinkConfig] with Logging {
 
   def output(spark: SparkSession, ds: Dataset[Row]): Unit = {
     var options = Map(
-      "spark.starrocks.write.fe.urls.http" -> config.getHttpUrl,
+      "spark.starrocks.write.fe.urls.http" -> config.getUrl,
       "spark.starrocks.write.fe.urls.jdbc" -> config.getJdbcUrl,
       "spark.starrocks.write.username" -> config.getUser,
       "spark.starrocks.write.password" -> config.getPassword,
@@ -42,13 +40,10 @@ class StarrocksSink extends DataCalcSink[StarrocksSinkConfig] with Logging {
       options = config.getOptions.asScala.toMap ++ options
     }
 
-    val writer = ds.write.format("starrocks_writer")
-    if (StringUtils.isNotBlank(config.getSaveMode)) {
-      writer.mode(config.getSaveMode)
-    }
+    val writer = ds.write.format("starrocks_writer").mode("append")
 
     logger.info(
-      s"Save data from starrocks httpUrl: ${config.getHttpUrl}, targetDatabase: ${config.getTargetDatabase}, targetTable: ${config.getTargetTable}"
+      s"Save data from starrocks url: ${config.getUrl}, targetDatabase: ${config.getTargetDatabase}, targetTable: ${config.getTargetTable}"
     )
     writer.options(options).save()
   }

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSink.scala
@@ -19,6 +19,7 @@ package org.apache.linkis.engineplugin.spark.datacalc.sink
 
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcSink
+
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 
 import scala.collection.JavaConverters._
@@ -40,6 +41,7 @@ class StarrocksSink extends DataCalcSink[StarrocksSinkConfig] with Logging {
       options = config.getOptions.asScala.toMap ++ options
     }
 
+    // todo The starrocks connector currently only supports the 'append' mode, using the starrocks 'Primary Key table' to do 'upsert'
     val writer = ds.write.format("starrocks_writer").mode("append")
 
     logger.info(

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSink.scala
@@ -28,6 +28,7 @@ class StarrocksSink extends DataCalcSink[StarrocksSinkConfig] with Logging {
 
   def output(spark: SparkSession, ds: Dataset[Row]): Unit = {
     var options = Map(
+      "spark.starrocks.conf" -> "write",
       "spark.starrocks.write.fe.urls.http" -> config.getUrl,
       "spark.starrocks.write.fe.urls.jdbc" -> config.getJdbcUrl,
       "spark.starrocks.write.username" -> config.getUser,

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/StarrocksSink.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.datacalc.sink
+
+import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcSink
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+
+import scala.collection.JavaConverters._
+
+class StarrocksSink extends DataCalcSink[StarrocksSinkConfig] with Logging {
+
+  def output(spark: SparkSession, ds: Dataset[Row]): Unit = {
+    var options = Map(
+      "spark.starrocks.write.fe.urls.http" -> config.getHttpUrl,
+      "spark.starrocks.write.fe.urls.jdbc" -> config.getJdbcUrl,
+      "spark.starrocks.write.username" -> config.getUser,
+      "spark.starrocks.write.password" -> config.getPassword,
+      "spark.starrocks.write.properties.ignore_json_size" -> "true",
+      "spark.starrocks.write.database" -> config.getTargetDatabase,
+      "spark.starrocks.write.table" -> config.getTargetTable
+    )
+
+    if (config.getOptions != null && !config.getOptions.isEmpty) {
+      options = config.getOptions.asScala.toMap ++ options
+    }
+
+    val writer = ds.write.format("starrocks_writer")
+    if (StringUtils.isNotBlank(config.getSaveMode)) {
+      writer.mode(config.getSaveMode)
+    }
+
+    logger.info(
+      s"Save data from starrocks httpUrl: ${config.getHttpUrl}, targetDatabase: ${config.getTargetDatabase}, targetTable: ${config.getTargetTable}"
+    )
+    writer.options(options).save()
+  }
+
+}

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/source/StarrocksSource.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/source/StarrocksSource.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.datacalc.source
+
+import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcSource
+
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+
+class StarrocksSource extends DataCalcSource[StarrocksSourceConfig] with Logging {
+
+  override def getData(spark: SparkSession): Dataset[Row] = {
+    val reader = spark.read.format("starrocks")
+
+    if (config.getOptions != null && !config.getOptions.isEmpty) {
+      reader.options(config.getOptions)
+    }
+
+    logger.info(
+      s"Load data from starrocks httpUrl: ${config.getHttpUrl}, sourceDatabase: ${config.getSourceDatabase}, sourceTable: ${config.getSourceTable}"
+    )
+
+    reader
+      .option(
+        "starrocks.table.identifier",
+        String.format("%s.%s", config.getSourceDatabase, config.getSourceTable)
+      )
+      .option("starrocks.fenodes", config.getHttpUrl)
+      .option("user", config.getUser)
+      .option("password", config.getPassword)
+      .load()
+  }
+
+}

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/source/StarrocksSource.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/source/StarrocksSource.scala
@@ -32,7 +32,7 @@ class StarrocksSource extends DataCalcSource[StarrocksSourceConfig] with Logging
     }
 
     logger.info(
-      s"Load data from starrocks httpUrl: ${config.getHttpUrl}, sourceDatabase: ${config.getSourceDatabase}, sourceTable: ${config.getSourceTable}"
+      s"Load data from starrocks url: ${config.getUrl}, sourceDatabase: ${config.getSourceDatabase}, sourceTable: ${config.getSourceTable}"
     )
 
     reader
@@ -40,7 +40,7 @@ class StarrocksSource extends DataCalcSource[StarrocksSourceConfig] with Logging
         "starrocks.table.identifier",
         String.format("%s.%s", config.getSourceDatabase, config.getSourceTable)
       )
-      .option("starrocks.fenodes", config.getHttpUrl)
+      .option("starrocks.fenodes", config.getUrl)
       .option("user", config.getUser)
       .option("password", config.getPassword)
       .load()


### PR DESCRIPTION
Spark etl support starrocks
spark connecot starrocks uses load, which has better performance than jdbc