### PR TITLE
Flink support native kubernetes application mode

### DIFF
--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/org/apache/linkis/engineconn/executor/entity/KubernetesExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/executor-core/src/main/scala/org/apache/linkis/engineconn/executor/entity/KubernetesExecutor.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconn.executor.entity
+
+trait KubernetesExecutor extends Executor {
+
+  def getKubernetesClusterID: String
+
+  def getApplicationURL: String
+
+  def getNamespace: String
+
+}

--- a/linkis-engineconn-plugins/flink/pom.xml
+++ b/linkis-engineconn-plugins/flink/pom.xml
@@ -176,6 +176,12 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
+      <artifactId>flink-kubernetes_${scala.binary.version}</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-hive_${scala.binary.version}</artifactId>
       <version>${flink.version}</version>
     </dependency>

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/AbstractApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/AbstractApplicationClusterDescriptorAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconnplugin.flink.client.deployment;
+
+import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
+import org.apache.linkis.engineconnplugin.flink.exception.JobExecutionException;
+
+public abstract class AbstractApplicationClusterDescriptorAdapter extends ClusterDescriptorAdapter {
+
+  AbstractApplicationClusterDescriptorAdapter(ExecutionContext executionContext) {
+    super(executionContext);
+  }
+
+  public abstract void deployCluster(String[] programArguments, String applicationClassName)
+      throws JobExecutionException;
+
+  public abstract boolean initJobId() throws Exception;
+
+  @Override
+  public boolean isGloballyTerminalState() {
+    return false;
+  }
+}

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/ClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/ClusterDescriptorAdapter.java
@@ -55,7 +55,12 @@ public abstract class ClusterDescriptorAdapter implements Closeable {
   // jobId is not null only after job is submitted
   private JobID jobId;
   protected ApplicationId clusterID;
+
+  protected String kubernetesClusterID;
   protected ClusterClient<ApplicationId> clusterClient;
+
+  protected ClusterClient<String> kubernetesClusterClient;
+
   private YarnClusterDescriptor clusterDescriptor;
 
   public void setJobId(JobID jobId) {
@@ -68,6 +73,10 @@ public abstract class ClusterDescriptorAdapter implements Closeable {
 
   public ApplicationId getClusterID() {
     return clusterID;
+  }
+
+  public String getKubernetesClusterID() {
+    return kubernetesClusterID;
   }
 
   public String getWebInterfaceUrl() {

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/ClusterDescriptorAdapterFactory.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/ClusterDescriptorAdapterFactory.java
@@ -20,20 +20,24 @@ package org.apache.linkis.engineconnplugin.flink.client.deployment;
 import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
 
 import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.yarn.configuration.YarnDeploymentTarget;
 
 /** Cluster Descriptor Adapter Factory(集群交互适配器工厂) */
 public class ClusterDescriptorAdapterFactory {
 
   public static ClusterDescriptorAdapter create(ExecutionContext executionContext) {
-    String yarnDeploymentTarget = executionContext.getFlinkConfig().get(DeploymentOptions.TARGET);
+    String flinkDeploymentTarget = executionContext.getFlinkConfig().get(DeploymentOptions.TARGET);
     ClusterDescriptorAdapter clusterDescriptorAdapter = null;
-    if (YarnDeploymentTarget.PER_JOB.getName().equals(yarnDeploymentTarget)) {
+    if (YarnDeploymentTarget.PER_JOB.getName().equals(flinkDeploymentTarget)) {
       clusterDescriptorAdapter = new YarnPerJobClusterDescriptorAdapter(executionContext);
-    } else if (YarnDeploymentTarget.APPLICATION.getName().equals(yarnDeploymentTarget)) {
+    } else if (YarnDeploymentTarget.APPLICATION.getName().equals(flinkDeploymentTarget)) {
       clusterDescriptorAdapter = new YarnApplicationClusterDescriptorAdapter(executionContext);
-    } else if (YarnDeploymentTarget.SESSION.getName().equals(yarnDeploymentTarget)) {
+    } else if (YarnDeploymentTarget.SESSION.getName().equals(flinkDeploymentTarget)) {
       clusterDescriptorAdapter = new YarnSessionClusterDescriptorAdapter(executionContext);
+    } else if (KubernetesDeploymentTarget.APPLICATION.getName().equals(flinkDeploymentTarget)) {
+      clusterDescriptorAdapter =
+          new KubernetesApplicationClusterDescriptorAdapter(executionContext);
     }
     return clusterDescriptorAdapter;
   }

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
@@ -59,7 +59,7 @@ public class KubernetesApplicationClusterDescriptorAdapter
   }
 
   public boolean initJobId() throws Exception {
-    clusterClient
+    kubernetesClusterClient
         .listJobs()
         .thenAccept(
             list ->

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
@@ -24,16 +24,15 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.client.program.ClusterClientProvider;
-import org.apache.flink.yarn.YarnClusterDescriptor;
-import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.flink.kubernetes.KubernetesClusterDescriptor;
 
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-public class YarnApplicationClusterDescriptorAdapter
+public class KubernetesApplicationClusterDescriptorAdapter
     extends AbstractApplicationClusterDescriptorAdapter {
 
-  YarnApplicationClusterDescriptorAdapter(ExecutionContext executionContext) {
+  KubernetesApplicationClusterDescriptorAdapter(ExecutionContext executionContext) {
     super(executionContext);
   }
 
@@ -45,18 +44,18 @@ public class YarnApplicationClusterDescriptorAdapter
         this.executionContext
             .getClusterClientFactory()
             .getClusterSpecification(this.executionContext.getFlinkConfig());
-    YarnClusterDescriptor clusterDescriptor = this.executionContext.createClusterDescriptor();
+    KubernetesClusterDescriptor clusterDescriptor =
+        this.executionContext.createKubernetesClusterDescriptor();
     try {
-      ClusterClientProvider<ApplicationId> clusterClientProvider =
+      ClusterClientProvider<String> clusterClientProvider =
           clusterDescriptor.deployApplicationCluster(
               clusterSpecification, applicationConfiguration);
-      clusterClient = clusterClientProvider.getClusterClient();
-      super.clusterID = clusterClient.getClusterId();
-      super.webInterfaceUrl = clusterClient.getWebInterfaceURL();
+      kubernetesClusterClient = clusterClientProvider.getClusterClient();
+      super.kubernetesClusterID = kubernetesClusterClient.getClusterId();
+      super.webInterfaceUrl = kubernetesClusterClient.getWebInterfaceURL();
     } catch (Exception e) {
       throw new JobExecutionException(ExceptionUtils.getRootCauseMessage(e), e);
     }
-    bindApplicationId();
   }
 
   public boolean initJobId() throws Exception {

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/factory/LinkisKubernetesClusterClientFactory.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/factory/LinkisKubernetesClusterClientFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconnplugin.flink.client.factory;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
+import org.apache.flink.kubernetes.KubernetesClusterDescriptor;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.DefaultKubeClientFactory;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.util.AbstractID;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+public class LinkisKubernetesClusterClientFactory extends KubernetesClusterClientFactory
+    implements Closeable {
+
+  private static final String CLUSTER_ID_PREFIX = "flink-cluster-";
+
+  private Configuration configuration;
+
+  private FlinkKubeClient flinkKubeClient;
+
+  private String clusterId;
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LinkisKubernetesClusterClientFactory.class);
+
+  @Override
+  public KubernetesClusterDescriptor createClusterDescriptor(Configuration configuration) {
+    this.configuration = configuration;
+
+    checkNotNull(configuration);
+    if (!configuration.contains(KubernetesConfigOptions.CLUSTER_ID)) {
+      this.clusterId = generateClusterId();
+      configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
+    }
+    this.flinkKubeClient = DefaultKubeClientFactory.getInstance().fromConfiguration(configuration);
+    return new KubernetesClusterDescriptor(configuration, flinkKubeClient);
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      flinkKubeClient.stopAndCleanupCluster(clusterId);
+    } catch (Exception e) {
+      flinkKubeClient.handleException(e);
+      LOG.error("Could not kill Kubernetes cluster " + clusterId);
+    }
+
+    try {
+      flinkKubeClient.close();
+    } catch (Exception e) {
+      flinkKubeClient.handleException(e);
+      LOG.error("failed to close client, exception {}", e.toString());
+    }
+  }
+
+  private String generateClusterId() {
+    final String randomID = new AbstractID().toString();
+    return (CLUSTER_ID_PREFIX + randomID).substring(0, Constants.MAXIMUM_CHARACTERS_OF_CLUSTER_ID);
+  }
+}

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/errorcode/FlinkErrorCodeSummary.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/errorcode/FlinkErrorCodeSummary.java
@@ -37,6 +37,9 @@ public enum FlinkErrorCodeSummary implements LinkisErrorCode {
   PLANNER_MUST_THESE(16020, "Planner must be one of:{}(Planner 必须是以下之一)."),
   EXECUTION_MUST_THESE(16020, "Execution type must be one of:{}(Execution 类型必须是以下之一)."),
   NOT_SUPPORTED_YARNTARGET(16020, "Not supported YarnDeploymentTarget(不支持 YarnDeploymentTarget)"),
+
+  KUBERNETES_CONFIG_FILE_EMPTY(
+      16020, "The kubernetes config file is empty:{}(kubernetes config file为空)."),
   UNKNOWN_CHECKPOINT_MODE(16020, "Unknown checkpoint mode:{0}(未知的 checkpoint 模式)."),
   HUDIJARS_NOT_EXISTS(16020, "hudi jars does not exist(hudi jars 不存在)."),
   PATH_NOT_EXIST(16020, "The path:{0} is not exist or is not a directory(路径：{0}不存在或不是目录)"),

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/errorcode/FlinkErrorCodeSummary.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/errorcode/FlinkErrorCodeSummary.java
@@ -102,6 +102,9 @@ public enum FlinkErrorCodeSummary implements LinkisErrorCode {
   NOT_SUPPORT_FLINK(
       20001,
       "Not support ClusterDescriptorAdapter for flink application.(不支持 flink 应用的 ClusterDescriptorAdapter.)"),
+  KUBERNETES_IS_NULL(
+      20001,
+      "The application start failed, since kubernetes kubernetesClusterID is null.(应用程序启动失败，因为 kubernetes kubernetesClusterID  为 null.)"),
   YARN_IS_NULL(
       20001,
       "The application start failed, since yarn applicationId is null.(应用程序启动失败，因为 yarn applicationId 为 null.)"),

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
@@ -92,39 +92,39 @@ object FlinkEnvConfiguration {
     CommonVars("flink.client.request.timeout", new TimeType("30s"))
 
   val FLINK_EXECUTION_TARGET =
-    CommonVars("flink.execution.target", FlinkExecutionTargetType.YARN_PER_JOB)
+    CommonVars("linkis.flink.execution.target", FlinkExecutionTargetType.YARN_PER_JOB)
 
   val FLINK_KUBERNETES_CONFIG_FILE =
     CommonVars(
-      "flink.kubernetes.config.file",
+      "linkis.flink.kubernetes.config.file",
       "",
       "The kubernetes config file will be used to create the client. The default is located at ~/.kube/config"
     )
 
   val FLINK_KUBERNETES_NAMESPACE =
     CommonVars(
-      "flink.kubernetes.namespace",
+      "linkis.flink.kubernetes.namespace",
       "default",
       "The namespace that will be used for running the jobmanager and taskmanager pods."
     )
 
   val FLINK_KUBERNETES_CONTAINER_IMAGE =
     CommonVars(
-      "flink.kubernetes.container.image",
+      "linkis.flink.kubernetes.container.image",
       "apache/flink:1.12.2-scala_2.12-java8",
       "Image to use for Flink containers."
     )
 
   val FLINK_KUBERNETES_CLUSTER_ID =
     CommonVars(
-      "flink.kubernetes.cluster-id",
+      "linkis.flink.kubernetes.cluster-id",
       "",
       "The cluster-id, which should be no more than 45 characters, is used for identifying a unique Flink cluster."
     )
 
   val FLINK_KUBERNETES_SERVICE_ACCOUNT =
     CommonVars(
-      "flink.kubernetes.service-account",
+      "linkis.flink.kubernetes.service-account",
       "default",
       "Service account that is used by taskmanager within kubernetes cluster."
     )

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
@@ -91,6 +91,44 @@ object FlinkEnvConfiguration {
   val FLINK_CLIENT_REQUEST_TIMEOUT =
     CommonVars("flink.client.request.timeout", new TimeType("30s"))
 
+  val FLINK_EXECUTION_TARGET =
+    CommonVars("flink.execution.target", FlinkExecutionTargetType.YARN_PER_JOB)
+
+  val FLINK_KUBERNETES_CONFIG_FILE =
+    CommonVars(
+      "flink.kubernetes.config.file",
+      "",
+      "The kubernetes config file will be used to create the client. The default is located at ~/.kube/config"
+    )
+
+  val FLINK_KUBERNETES_NAMESPACE =
+    CommonVars(
+      "flink.kubernetes.namespace",
+      "default",
+      "The namespace that will be used for running the jobmanager and taskmanager pods."
+    )
+
+  val FLINK_KUBERNETES_CONTAINER_IMAGE =
+    CommonVars(
+      "flink.kubernetes.container.image",
+      "flink:1.12.2",
+      "Image to use for Flink containers."
+    )
+
+  val FLINK_KUBERNETES_CLUSTER_ID =
+    CommonVars(
+      "flink.kubernetes.cluster-id",
+      "",
+      "The cluster-id, which should be no more than 45 characters, is used for identifying a unique Flink cluster."
+    )
+
+  val FLINK_KUBERNETES_SERVICE_ACCOUNT =
+    CommonVars(
+      "flink.kubernetes.service-account",
+      "",
+      "Service account that is used by taskmanager within kubernetes cluster."
+    )
+
   val FLINK_ONCE_APP_STATUS_FETCH_INTERVAL =
     CommonVars("flink.app.fetch.status.interval", new TimeType("5s"))
 

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
@@ -111,7 +111,7 @@ object FlinkEnvConfiguration {
   val FLINK_KUBERNETES_CONTAINER_IMAGE =
     CommonVars(
       "flink.kubernetes.container.image",
-      "flink:1.12.2",
+      "apache/flink:1.12.2-scala_2.12-java8",
       "Image to use for Flink containers."
     )
 
@@ -125,7 +125,7 @@ object FlinkEnvConfiguration {
   val FLINK_KUBERNETES_SERVICE_ACCOUNT =
     CommonVars(
       "flink.kubernetes.service-account",
-      "",
+      "default",
       "Service account that is used by taskmanager within kubernetes cluster."
     )
 

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkExecutionTargetType.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkExecutionTargetType.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineconnplugin.flink.config
+
+object FlinkExecutionTargetType {
+
+  val YARN_PER_JOB: String = "yarn-per-job"
+  val YARN_SESSION: String = "yarn-session"
+  val YARN_APPLICATION: String = "yarn-application"
+
+  val KUBERNETES_APPLICATION: String = "kubernetes-application"
+  val KUBERNETES_SESSION: String = "kubernetes-session"
+  val KUBERNETES_OPERATOR: String = "kubernetes-operator"
+
+}

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkExecutionTargetType.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkExecutionTargetType.scala
@@ -27,4 +27,16 @@ object FlinkExecutionTargetType {
   val KUBERNETES_SESSION: String = "kubernetes-session"
   val KUBERNETES_OPERATOR: String = "kubernetes-operator"
 
+  def isYarnExecutionTargetType(targetType: String): Boolean = {
+    targetType.equalsIgnoreCase(YARN_PER_JOB) || targetType.equalsIgnoreCase(
+      YARN_SESSION
+    ) || targetType.equalsIgnoreCase(YARN_APPLICATION)
+  }
+
+  def isKubernetesExecutionTargetType(targetType: String): Boolean = {
+    targetType.equalsIgnoreCase(KUBERNETES_APPLICATION) || targetType.equalsIgnoreCase(
+      KUBERNETES_SESSION
+    ) || targetType.equalsIgnoreCase(KUBERNETES_OPERATOR)
+  }
+
 }

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/context/EnvironmentContext.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/context/EnvironmentContext.scala
@@ -49,7 +49,7 @@ class EnvironmentContext(
 
   private var flinkConfig: Configuration = _
 
-  private var deploymentTarget: YarnDeploymentTarget = YarnDeploymentTarget.PER_JOB
+  private var deploymentTarget: String = YarnDeploymentTarget.PER_JOB.getName
 
   def this(
       defaultEnv: Environment,
@@ -88,10 +88,9 @@ class EnvironmentContext(
     this.flinkConfig.set(YarnConfigOptions.FLINK_DIST_JAR, distJarPath)
   }
 
-  def setDeploymentTarget(deploymentTarget: YarnDeploymentTarget): Unit = this.deploymentTarget =
-    deploymentTarget
+  def setDeploymentTarget(deploymentTarget: String): Unit = this.deploymentTarget = deploymentTarget
 
-  def getDeploymentTarget: YarnDeploymentTarget = deploymentTarget
+  def getDeploymentTarget: String = deploymentTarget
 
   def getProvidedLibDirs: util.List[String] = providedLibDirs
 

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/context/EnvironmentContext.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/context/EnvironmentContext.scala
@@ -19,6 +19,7 @@ package org.apache.linkis.engineconnplugin.flink.context
 
 import org.apache.linkis.engineconnplugin.flink.client.config.Environment
 import org.apache.linkis.engineconnplugin.flink.client.factory.LinkisYarnClusterClientFactory
+import org.apache.linkis.engineconnplugin.flink.config.FlinkExecutionTargetType
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.flink.configuration.{
@@ -61,7 +62,8 @@ class EnvironmentContext(
       flinkLibRemotePath: String,
       providedLibDirsArray: Array[String],
       shipDirsArray: Array[String],
-      dependencies: util.List[URL]
+      dependencies: util.List[URL],
+      flinkExecutionTarget: String
   ) {
     this(
       defaultEnv,
@@ -82,10 +84,12 @@ class EnvironmentContext(
     if (null != systemConfiguration) this.flinkConfig.addAll(systemConfiguration)
     // set flink conf-dir(设置 flink conf目录)
     this.flinkConfig.set(DeploymentOptionsInternal.CONF_DIR, this.flinkConfDir)
-    // set yarn conf-dir(设置 yarn conf目录)
-    this.flinkConfig.set(LinkisYarnClusterClientFactory.YARN_CONFIG_DIR, this.yarnConfDir)
-    // set flink dist-jar(设置 flink dist jar)
-    this.flinkConfig.set(YarnConfigOptions.FLINK_DIST_JAR, distJarPath)
+    if (!FlinkExecutionTargetType.isKubernetesExecutionTargetType(flinkExecutionTarget)) {
+      // set yarn conf-dir(设置 yarn conf目录)
+      this.flinkConfig.set(LinkisYarnClusterClientFactory.YARN_CONFIG_DIR, this.yarnConfDir)
+      // set flink dist-jar(设置 flink dist jar)
+      this.flinkConfig.set(YarnConfigOptions.FLINK_DIST_JAR, distJarPath)
+    }
   }
 
   def setDeploymentTarget(deploymentTarget: String): Unit = this.deploymentTarget = deploymentTarget

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkJarOnceExecutor.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkJarOnceExecutor.scala
@@ -19,7 +19,7 @@ package org.apache.linkis.engineconnplugin.flink.executor
 
 import org.apache.linkis.common.utils.Utils
 import org.apache.linkis.engineconn.once.executor.OnceExecutorExecutionContext
-import org.apache.linkis.engineconnplugin.flink.client.deployment.YarnApplicationClusterDescriptorAdapter
+import org.apache.linkis.engineconnplugin.flink.client.deployment.AbstractApplicationClusterDescriptorAdapter
 import org.apache.linkis.engineconnplugin.flink.config.FlinkEnvConfiguration._
 import org.apache.linkis.engineconnplugin.flink.context.FlinkEngineConnContext
 
@@ -30,7 +30,7 @@ import scala.concurrent.duration.Duration
 class FlinkJarOnceExecutor(
     override val id: Long,
     override protected val flinkEngineConnContext: FlinkEngineConnContext
-) extends FlinkOnceExecutor[YarnApplicationClusterDescriptorAdapter] {
+) extends FlinkOnceExecutor[AbstractApplicationClusterDescriptorAdapter] {
 
   override def doSubmit(
       onceExecutorExecutionContext: OnceExecutorExecutionContext,

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkOnceExecutor.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkOnceExecutor.scala
@@ -30,12 +30,14 @@ import org.apache.linkis.engineconnplugin.flink.config.FlinkEnvConfiguration.{
   FLINK_ONCE_APP_STATUS_FETCH_FAILED_MAX,
   FLINK_ONCE_APP_STATUS_FETCH_INTERVAL
 }
+import org.apache.linkis.engineconnplugin.flink.config.FlinkExecutionTargetType
 import org.apache.linkis.engineconnplugin.flink.errorcode.FlinkErrorCodeSummary._
 import org.apache.linkis.engineconnplugin.flink.exception.ExecutorInitException
 import org.apache.linkis.engineconnplugin.flink.executor.interceptor.FlinkJobSubmitInterceptor
 import org.apache.linkis.manager.common.entity.enumeration.NodeStatus
 
 import org.apache.flink.api.common.JobStatus
+import org.apache.flink.configuration.DeploymentOptions
 
 import java.util.concurrent.{Future, TimeUnit}
 
@@ -61,23 +63,32 @@ trait FlinkOnceExecutor[T <: ClusterDescriptorAdapter]
       case (k, v) if v != null => k -> v.toString
       case (k, _) => k -> null
     }.toMap
-    Option(interceptor).foreach(op => op.beforeSubmit(onceExecutorExecutionContext))
-    Utils.tryCatch {
-      doSubmit(onceExecutorExecutionContext, options)
-      Option(interceptor).foreach(op => op.afterSubmitSuccess(onceExecutorExecutionContext))
-    } { t: Throwable =>
-      Option(interceptor).foreach(op => op.afterSubmitFail(onceExecutorExecutionContext, t))
-      throw t
-    }
+    doSubmit(onceExecutorExecutionContext, options)
     if (isCompleted) return
-    if (null == clusterDescriptor.getClusterID) {
-      throw new ExecutorInitException(YARN_IS_NULL.getErrorDesc)
+
+    val flinkDeploymentTarget =
+      flinkEngineConnContext.getExecutionContext.getFlinkConfig.get(DeploymentOptions.TARGET)
+
+    if (FlinkExecutionTargetType.isYarnExecutionTargetType(flinkDeploymentTarget)) {
+      if (null == clusterDescriptor.getClusterID) {
+        throw new ExecutorInitException(YARN_IS_NULL.getErrorDesc)
+      }
+      setApplicationId(clusterDescriptor.getClusterID.toString)
+      setApplicationURL(clusterDescriptor.getWebInterfaceUrl)
+      logger.info(
+        s"Application is started, applicationId: $getApplicationId, applicationURL: $getApplicationURL."
+      )
+    } else if (FlinkExecutionTargetType.isKubernetesExecutionTargetType(flinkDeploymentTarget)) {
+      if (null == clusterDescriptor.getKubernetesClusterID) {
+        throw new ExecutorInitException(KUBERNETES_IS_NULL.getErrorDesc)
+      }
+      setKubernetesClusterID(clusterDescriptor.getKubernetesClusterID)
+      setApplicationURL(clusterDescriptor.getWebInterfaceUrl)
+      logger.info(
+        s"Application is started, applicationId: $getApplicationId, applicationURL: $getApplicationURL."
+      )
     }
-    setApplicationId(clusterDescriptor.getClusterID.toString)
-    setApplicationURL(clusterDescriptor.getWebInterfaceUrl)
-    logger.info(
-      s"Application is started, applicationId: $getApplicationId, applicationURL: $getApplicationURL."
-    )
+
     if (clusterDescriptor.getJobId != null) setJobID(clusterDescriptor.getJobId.toHexString)
   }
 

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/factory/FlinkEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/factory/FlinkEngineConnFactory.scala
@@ -22,7 +22,10 @@ import org.apache.linkis.engineconn.common.creation.EngineCreationContext
 import org.apache.linkis.engineconnplugin.flink.client.config.Environment
 import org.apache.linkis.engineconnplugin.flink.client.config.entries.ExecutionEntry
 import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext
-import org.apache.linkis.engineconnplugin.flink.config.FlinkEnvConfiguration
+import org.apache.linkis.engineconnplugin.flink.config.{
+  FlinkEnvConfiguration,
+  FlinkExecutionTargetType
+}
 import org.apache.linkis.engineconnplugin.flink.config.FlinkEnvConfiguration._
 import org.apache.linkis.engineconnplugin.flink.config.FlinkResourceConfiguration._
 import org.apache.linkis.engineconnplugin.flink.context.{EnvironmentContext, FlinkEngineConnContext}
@@ -41,6 +44,7 @@ import org.apache.linkis.manager.label.entity.engine.EngineType.EngineType
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.flink.configuration._
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings
 import org.apache.flink.streaming.api.CheckpointingMode
 import org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup
@@ -193,9 +197,14 @@ class FlinkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
         SavepointRestoreSettings.forPath(savePointPath, allowNonRestoredState)
       SavepointRestoreSettings.toConfiguration(savepointRestoreSettings, flinkConfig)
     }
+
+    val flinkExecutionTarget = FLINK_EXECUTION_TARGET.getValue(options)
+
     // Configure user-entrance jar. Can be HDFS file, but only support 1 jar
     val flinkMainClassJar = FLINK_APPLICATION_MAIN_CLASS_JAR.getValue(options)
-    if (StringUtils.isNotBlank(flinkMainClassJar)) {
+    if (
+        StringUtils.isNotBlank(flinkMainClassJar) && !flinkExecutionTarget.startsWith("kubernetes")
+    ) {
       val flinkMainClassJarPath =
         if (new File(flinkMainClassJar).exists()) flinkMainClassJar
         else getClass.getClassLoader.getResource(flinkMainClassJar).getPath
@@ -205,12 +214,53 @@ class FlinkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
       flinkConfig.set(PipelineOptions.JARS, Collections.singletonList(flinkMainClassJarPath))
       flinkConfig.set(DeploymentOptions.TARGET, YarnDeploymentTarget.APPLICATION.getName)
       flinkConfig.setBoolean(DeploymentOptions.ATTACHED, FLINK_EXECUTION_ATTACHED.getValue(options))
-      context.setDeploymentTarget(YarnDeploymentTarget.APPLICATION)
+      context.setDeploymentTarget(YarnDeploymentTarget.APPLICATION.getName)
       addApplicationLabels(engineCreationContext)
     } else if (isOnceEngineConn(engineCreationContext.getLabels())) {
       flinkConfig.set(DeploymentOptions.TARGET, YarnDeploymentTarget.PER_JOB.getName)
     } else {
       flinkConfig.set(DeploymentOptions.TARGET, YarnDeploymentTarget.SESSION.getName)
+    }
+
+    // set kubernetes config
+    if (
+        StringUtils.isNotBlank(flinkExecutionTarget) && (flinkExecutionTarget.equalsIgnoreCase(
+          FlinkExecutionTargetType.KUBERNETES_APPLICATION
+        ) || flinkExecutionTarget.equalsIgnoreCase(FlinkExecutionTargetType.KUBERNETES_SESSION))
+    ) {
+      flinkConfig.set(DeploymentOptions.TARGET, flinkExecutionTarget)
+      context.setDeploymentTarget(flinkExecutionTarget)
+
+      val kubernetesConfigFile = FLINK_KUBERNETES_CONFIG_FILE.getValue(options)
+      if (StringUtils.isBlank(kubernetesConfigFile)) {
+        throw new FlinkInitFailedException(KUBERNETES_CONFIG_FILE_EMPTY.getErrorDesc)
+      }
+
+      flinkConfig.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubernetesConfigFile)
+
+      flinkConfig.set(
+        KubernetesConfigOptions.NAMESPACE,
+        FLINK_KUBERNETES_NAMESPACE.getValue(options)
+      )
+      flinkConfig.set(
+        KubernetesConfigOptions.CONTAINER_IMAGE,
+        FLINK_KUBERNETES_CONTAINER_IMAGE.getValue(options)
+      )
+      val kubernetesClusterId = FLINK_KUBERNETES_CLUSTER_ID.getValue(options)
+      if (StringUtils.isNotBlank(kubernetesClusterId)) {
+        flinkConfig.set(KubernetesConfigOptions.CLUSTER_ID, kubernetesClusterId)
+      }
+
+      flinkConfig.set(KubernetesConfigOptions.FLINK_CONF_DIR, flinkConfDir)
+      val serviceAccount = FLINK_KUBERNETES_SERVICE_ACCOUNT.getValue(options)
+      if (StringUtils.isNotBlank(serviceAccount)) {
+        flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT, serviceAccount)
+        flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_SERVICE_ACCOUNT, serviceAccount)
+      }
+      val flinkMainClassJar = FLINK_APPLICATION_MAIN_CLASS_JAR.getValue(options)
+      if (StringUtils.isNotBlank(flinkMainClassJar)) {
+        flinkConfig.set(PipelineOptions.JARS, Collections.singletonList(flinkMainClassJar))
+      }
     }
     context
   }
@@ -293,7 +343,9 @@ class FlinkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
       environmentContext: EnvironmentContext
   ): ExecutionContext = {
     val environment = environmentContext.getDeploymentTarget match {
-      case YarnDeploymentTarget.PER_JOB | YarnDeploymentTarget.SESSION =>
+      // Otherwise, an error is generated: stable identifier required, but PER_JOB.getName found.
+      case FlinkExecutionTargetType.YARN_PER_JOB | FlinkExecutionTargetType.YARN_SESSION |
+          FlinkExecutionTargetType.KUBERNETES_SESSION =>
         val planner = FlinkEnvConfiguration.FLINK_SQL_PLANNER.getValue(options)
         if (!ExecutionEntry.AVAILABLE_PLANNERS.contains(planner.toLowerCase(Locale.getDefault))) {
           throw new FlinkInitFailedException(
@@ -339,12 +391,12 @@ class FlinkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
           )
         }
         Environment.enrich(environmentContext.getDefaultEnv, properties, Collections.emptyMap())
-      case YarnDeploymentTarget.APPLICATION => null
+      case FlinkExecutionTargetType.YARN_APPLICATION |
+          FlinkExecutionTargetType.KUBERNETES_APPLICATION =>
+        null
       case t =>
-        logger.error(s"Not supported YarnDeploymentTarget ${t.getName}.")
-        throw new FlinkInitFailedException(
-          NOT_SUPPORTED_YARNTARGET.getErrorDesc + s" ${t.getName}."
-        )
+        logger.error(s"Not supported YarnDeploymentTarget ${t}.")
+        throw new FlinkInitFailedException(NOT_SUPPORTED_YARNTARGET.getErrorDesc + s" ${t}.")
     }
     val executionContext = ExecutionContext
       .builder(

--- a/tool/dependencies/known-dependencies.txt
+++ b/tool/dependencies/known-dependencies.txt
@@ -149,6 +149,7 @@ flink-table-common-1.12.2.jar
 flink-table-planner-blink_2.12-1.12.2.jar
 flink-table-runtime-blink_2.12-1.12.2.jar
 flink-yarn_2.12-1.12.2.jar
+flink-kubernetes_2.12-1.12.2.jar
 force-shading-1.12.2.jar
 freemarker-2.3.31.jar
 grizzled-slf4j_2.12-1.3.2.jar


### PR DESCRIPTION
Flink support native kubernetes application mode

Submitting tasks with Restful API

{
    "executionContent": {    
        "runType": "jar",
        "label.codeType": "jar",
        "code": "show tables"
    },
    "params": {
        "variable": {
        },
        "configuration": {
            "startup": {
                "label.codeType": "jar",
               "flink.sql.executionType": "batch",
               "linkis.flink.kubernetes.config.file": "/Users/chengjie/linkis/k8s_config/config",
               "linkis.flink.kubernetes.namespace": "default",
               "linkis.flink.kubernetes.container.image": "apache/flink:1.12.2-scala_2.12-java8",
               "linkis.flink.execution.target": "kubernetes-application",
               "linkis.flink.kubernetes.service-account": "default",
               "flink.conf.dir": "/Users/chengjie/hadoop/flink-1.12.2/conf",
               "flink.app.main.class.jar": "local:///opt/flink/examples/table/GettingStartedExample.jar"
            }
        }
    },
    "source":  {
        "scriptPath": "file:///tmp/hadoop/test.sql"
    },
    "labels": {
        "engineType": "flink-1.12.2",
        "engineConnMode": "once",
        "userCreator": "chengjie-IDE"
    }
}


flink.kubernetes.service-account : Service account that is used by jobmanager and taskmanager within kubernetes cluster. Notice that this can be overwritten by config options 'kubernetes.jobmanager.service-account' and 'kubernetes.taskmanager.service-account' for jobmanager and taskmanager respectively.


Task run successfully

![image](https://github.com/apache/linkis/assets/125547374/663e39ff-49e0-42cc-927a-bb9927e7fdb0)


![image](https://github.com/apache/linkis/assets/125547374/4e0defde-fcd1-42b1-b109-7aa3be686597)
