### PR TITLE
fix the bug that cant execute install.sh on postgresql

### DIFF
--- a/linkis-dist/package/db/linkis_ddl_pg.sql
+++ b/linkis-dist/package/db/linkis_ddl_pg.sql
@@ -744,6 +744,7 @@ CREATE TABLE linkis_cg_manager_service_instance (
 	"owner" varchar(32) NULL,
 	mark varchar(32) NULL,
 	identifier varchar(32) NULL,
+	ticketId varchar(255) NULL DEFAULT NULL,
 	update_time timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP,
 	create_time timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP,
 	updator varchar(32) NULL,


### PR DESCRIPTION

### What is the purpose of the change

Fix the bug that cant execute install.sh on postgresql

### Related issues/PRs

Related issues: #4708 


### Brief change log

- Modified the install.sh for pass the check env.
- Modified the linkis_ddl_pg.sql to address the issue of missing fields,


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.

