### PR TITLE
Fix the issue of slow reading results when using S3.

### DIFF
--- a/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/utils/StorageUtils.java
+++ b/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/utils/StorageUtils.java
@@ -227,7 +227,12 @@ public class StorageUtils {
     int readLen = 0;
     try {
       int count = 0;
-      while (readLen < len) {
+      // 当使用s3存储结果文件时时，com.amazonaws.services.s3.model.S3InputStream无法正确读取.dolphin文件。需要在循环条件添加:
+      // readLen >= 0
+      // To resolve the issue when using S3 to store result files and
+      // com.amazonaws.services.s3.model.S3InputStream to read .dolphin files, you need to add the
+      // condition readLen >= 0 in the loop.
+      while (readLen < len && readLen >= 0) {
         count = inputStream.read(bytes, readLen, len - readLen);
 
         if (count == -1 && inputStream.available() < 1) {


### PR DESCRIPTION
### What is the purpose of the change

Fix the issue of slow reading results when using S3.

### Related issues/PRs

Related issues: #4741 


### Brief change log

- Modified StorageUtils  to fix the issue of slow reading results when using S3.


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [x] **If this is a code change**: I have written unit tests to fully verify the new behavior.

