### PR TITLE
[Bugfix] Task state changes should before engine state changes

### DIFF
--- a/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/execute/ComputationExecutor.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/execute/ComputationExecutor.scala
@@ -21,7 +21,10 @@ import org.apache.linkis.DataWorkCloudApplication
 import org.apache.linkis.common.log.LogUtils
 import org.apache.linkis.common.utils.{Logging, Utils}
 import org.apache.linkis.engineconn.acessible.executor.entity.AccessibleExecutor
-import org.apache.linkis.engineconn.acessible.executor.listener.event.TaskStatusChangedEvent
+import org.apache.linkis.engineconn.acessible.executor.listener.event.{
+  TaskResponseErrorEvent,
+  TaskStatusChangedEvent
+}
 import org.apache.linkis.engineconn.common.conf.{EngineConnConf, EngineConnConstant}
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
 import org.apache.linkis.engineconn.computation.executor.entity.EngineConnTask
@@ -237,11 +240,9 @@ abstract class ComputationExecutor(val outputPrintLimit: Int = 1000)
       response = response match {
         case _: OutputExecuteResponse =>
           succeedTasks.increase()
-          transformTaskStatus(engineConnTask, ExecutionNodeStatus.Succeed)
           SuccessExecuteResponse()
         case s: SuccessExecuteResponse =>
           succeedTasks.increase()
-          transformTaskStatus(engineConnTask, ExecutionNodeStatus.Succeed)
           s
         case _ => response
       }
@@ -261,7 +262,17 @@ abstract class ComputationExecutor(val outputPrintLimit: Int = 1000)
     taskCache.put(engineConnTask.getTaskId, engineConnTask)
     lastTask = engineConnTask
     val response = ensureOp {
-      toExecuteTask(engineConnTask)
+      val executeResponse = toExecuteTask(engineConnTask)
+      executeResponse match {
+        case successExecuteResponse: SuccessExecuteResponse =>
+          transformTaskStatus(engineConnTask, ExecutionNodeStatus.Succeed)
+        case errorExecuteResponse: ErrorExecuteResponse =>
+          listenerBusContext.getEngineConnSyncListenerBus.postToAll(
+            TaskResponseErrorEvent(engineConnTask.getTaskId, errorExecuteResponse.message)
+          )
+          transformTaskStatus(engineConnTask, ExecutionNodeStatus.Failed)
+      }
+      executeResponse
     }
 
     Utils.tryAndWarn(afterExecute(engineConnTask, response))

--- a/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
@@ -400,15 +400,7 @@ class TaskExecutionServiceImpl
     Utils.tryFinally {
       val jobId = JobUtils.getJobIdFromMap(task.getProperties)
       LoggerUtils.setJobIdMDC(jobId)
-      val response = executor.execute(task)
-      response match {
-        case ErrorExecuteResponse(message, throwable) =>
-          sendToEntrance(task, ResponseTaskError(task.getTaskId, message))
-          logger.error(message, throwable)
-          LogHelper.pushAllRemainLogs()
-          executor.transformTaskStatus(task, ExecutionNodeStatus.Failed)
-        case _ => logger.warn(s"task get response is $response")
-      }
+      executor.execute(task)
       clearCache(task.getTaskId)
     } {
       LoggerUtils.removeJobIdMDC()

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/EngineConnTimedLockService.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-executor/accessible-executor/src/main/scala/org/apache/linkis/engineconn/acessible/executor/service/EngineConnTimedLockService.scala
@@ -161,9 +161,7 @@ class EngineConnTimedLockService extends LockService with Logging {
         .toString
     )
     if (isLockExist(lock)) {
-      logger.info(
-        s"try to unlock lockEntity : lockString=$lockString,lockedBy=${engineConnLock.lockedBy.getId}"
-      )
+      logger.info(s"try to unlock lockEntity : lockString=$lockString")
       engineConnLock.release()
       this.lockString = null
       true


### PR DESCRIPTION
this close #4774

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->



### Related issues/PRs

Related issues: #4774



### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
