### PR TITLE
feat: support spark submit jar on k8s

### DIFF
--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/context/SparkConfig.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/context/SparkConfig.java
@@ -48,6 +48,9 @@ public class SparkConfig {
 
   private String k8sNamespace;
   private String k8sFileUploadPath;
+
+  private String k8sDriverRequestCores;
+  private String k8sExecutorRequestCores;
   private String deployMode = "client"; // ("client") // todo cluster
   private String appResource; // ("")
   private String appName; // ("")
@@ -168,6 +171,22 @@ public class SparkConfig {
 
   public void setK8sImage(String k8sImage) {
     this.k8sImage = k8sImage;
+  }
+
+  public String getK8sDriverRequestCores() {
+    return k8sDriverRequestCores;
+  }
+
+  public void setK8sDriverRequestCores(String k8sDriverRequestCores) {
+    this.k8sDriverRequestCores = k8sDriverRequestCores;
+  }
+
+  public String getK8sExecutorRequestCores() {
+    return k8sExecutorRequestCores;
+  }
+
+  public void setK8sExecutorRequestCores(String k8sExecutorRequestCores) {
+    this.k8sExecutorRequestCores = k8sExecutorRequestCores;
   }
 
   public String getJavaHome() {
@@ -435,6 +454,12 @@ public class SparkConfig {
         + '\''
         + ", k8sNamespace='"
         + k8sNamespace
+        + '\''
+        + ", k8sDriverRequestCores='"
+        + k8sDriverRequestCores
+        + '\''
+        + ", k8sExecutorRequestCores='"
+        + k8sExecutorRequestCores
         + '\''
         + ", deployMode='"
         + deployMode

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/ClusterDescriptorAdapterFactory.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/ClusterDescriptorAdapterFactory.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 public class ClusterDescriptorAdapterFactory {
 
   public static ClusterDescriptorAdapter create(ExecutionContext executionContext) {
-    String master = executionContext.getSparkConfig().getMaster(); // 获取一些配置信息
+    String master = executionContext.getSparkConfig().getMaster();
 
     ClusterDescriptorAdapter clusterDescriptorAdapter =
         new YarnApplicationClusterDescriptorAdapter(executionContext);

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/ClusterDescriptorAdapterFactory.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/ClusterDescriptorAdapterFactory.java
@@ -24,13 +24,18 @@ import org.apache.commons.lang3.StringUtils;
 public class ClusterDescriptorAdapterFactory {
 
   public static ClusterDescriptorAdapter create(ExecutionContext executionContext) {
-    String master = executionContext.getSparkConfig().getMaster();
+    String master = executionContext.getSparkConfig().getMaster(); // 获取一些配置信息
 
     ClusterDescriptorAdapter clusterDescriptorAdapter =
         new YarnApplicationClusterDescriptorAdapter(executionContext);
 
-    if (StringUtils.isNotBlank(master) && master.equalsIgnoreCase("k8s-operator")) {
-      clusterDescriptorAdapter = new KubernetesOperatorClusterDescriptorAdapter(executionContext);
+    if (StringUtils.isNotBlank(master)) {
+      if (master.equalsIgnoreCase("k8s-operator")) {
+        clusterDescriptorAdapter = new KubernetesOperatorClusterDescriptorAdapter(executionContext);
+      } else if (master.equalsIgnoreCase("k8s-jar")) {
+        clusterDescriptorAdapter =
+            new KubernetesApplicationClusterDescriptorAdapter(executionContext);
+      }
     }
 
     return clusterDescriptorAdapter;

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/ClusterDescriptorAdapterFactory.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/ClusterDescriptorAdapterFactory.java
@@ -32,7 +32,7 @@ public class ClusterDescriptorAdapterFactory {
     if (StringUtils.isNotBlank(master)) {
       if (master.equalsIgnoreCase("k8s-operator")) {
         clusterDescriptorAdapter = new KubernetesOperatorClusterDescriptorAdapter(executionContext);
-      } else if (master.equalsIgnoreCase("k8s-jar")) {
+      } else if (master.equalsIgnoreCase("k8s-native")) {
         clusterDescriptorAdapter =
             new KubernetesApplicationClusterDescriptorAdapter(executionContext);
       }

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.client.deployment;
+
+import org.apache.linkis.engineplugin.spark.client.context.ExecutionContext;
+import org.apache.linkis.engineplugin.spark.client.context.SparkConfig;
+import org.apache.linkis.engineplugin.spark.client.deployment.util.KubernetesHelper;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.util.Strings;
+import org.apache.spark.launcher.CustomSparkSubmitLauncher;
+import org.apache.spark.launcher.SparkAppHandle;
+import org.apache.spark.launcher.SparkLauncher;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KubernetesApplicationClusterDescriptorAdapter extends ClusterDescriptorAdapter {
+  private static final Logger logger =
+      LoggerFactory.getLogger(KubernetesOperatorClusterDescriptorAdapter.class);
+
+  protected SparkConfig sparkConfig;
+  protected KubernetesClient client;
+  protected String driverPodName;
+  protected String namespace;
+
+  public KubernetesApplicationClusterDescriptorAdapter(ExecutionContext executionContext) {
+    super(executionContext);
+    this.sparkConfig = executionContext.getSparkConfig();
+    this.client =
+        KubernetesHelper.getKubernetesClient(
+            this.sparkConfig.getK8sConfigFile(),
+            this.sparkConfig.getK8sMasterUrl(),
+            this.sparkConfig.getK8sUsername(),
+            this.sparkConfig.getK8sPassword());
+  }
+
+  public void deployCluster(String mainClass, String args, Map<String, String> confMap)
+      throws IOException {
+    SparkConfig sparkConfig = executionContext.getSparkConfig();
+    logger.info("===========SparkConfig: {}", sparkConfig);
+    logger.info("===========configMap: {}", confMap);
+    sparkLauncher = new CustomSparkSubmitLauncher();
+    // region set args
+    sparkLauncher
+        .setJavaHome(sparkConfig.getJavaHome())
+        .setSparkHome(sparkConfig.getSparkHome())
+        .setMaster(sparkConfig.getK8sMasterUrl())
+        .setDeployMode(sparkConfig.getDeployMode())
+        .setAppName(sparkConfig.getAppName())
+        .setVerbose(true);
+    this.driverPodName = sparkConfig.getAppName() + "-" + System.currentTimeMillis() + "-driver";
+    this.namespace = sparkConfig.getK8sNamespace();
+    setConf(sparkLauncher, "spark.app.name", sparkConfig.getAppName());
+    setConf(sparkLauncher, "spark.kubernetes.namespace", this.namespace);
+    setConf(sparkLauncher, "spark.kubernetes.container.image", sparkConfig.getK8sImage());
+    setConf(sparkLauncher, "spark.kubernetes.driver.pod.name", this.driverPodName);
+    setConf(
+        sparkLauncher,
+        "spark.kubernetes.driver.request.cores",
+        sparkConfig.getK8sDriverRequestCores());
+    setConf(
+        sparkLauncher,
+        "spark.kubernetes.executor.request.cores",
+        sparkConfig.getK8sExecutorRequestCores());
+    setConf(
+        sparkLauncher,
+        "spark.kubernetes.container.image.pullPolicy",
+        sparkConfig.getK8sImagePullPolicy());
+    setConf(
+        sparkLauncher,
+        "spark.kubernetes.authenticate.driver.serviceAccountName",
+        sparkConfig.getK8sServiceAccount());
+    if (confMap != null) confMap.forEach((k, v) -> sparkLauncher.setConf(k, v));
+
+    addSparkArg(sparkLauncher, "--jars", sparkConfig.getJars());
+    addSparkArg(sparkLauncher, "--packages", sparkConfig.getPackages());
+    addSparkArg(sparkLauncher, "--exclude-packages", sparkConfig.getExcludePackages());
+    addSparkArg(sparkLauncher, "--repositories", sparkConfig.getRepositories());
+    addSparkArg(sparkLauncher, "--files", sparkConfig.getFiles());
+    addSparkArg(sparkLauncher, "--archives", sparkConfig.getArchives());
+    addSparkArg(sparkLauncher, "--driver-memory", sparkConfig.getDriverMemory());
+    addSparkArg(sparkLauncher, "--driver-java-options", sparkConfig.getDriverJavaOptions());
+    addSparkArg(sparkLauncher, "--driver-library-path", sparkConfig.getDriverLibraryPath());
+    addSparkArg(sparkLauncher, "--driver-class-path", sparkConfig.getDriverClassPath());
+    addSparkArg(sparkLauncher, "--executor-memory", sparkConfig.getExecutorMemory());
+    addSparkArg(sparkLauncher, "--proxy-user", sparkConfig.getProxyUser());
+    addSparkArg(sparkLauncher, "--driver-cores", sparkConfig.getDriverCores().toString());
+    addSparkArg(sparkLauncher, "--total-executor-cores", sparkConfig.getTotalExecutorCores());
+    addSparkArg(sparkLauncher, "--executor-cores", sparkConfig.getExecutorCores().toString());
+    addSparkArg(sparkLauncher, "--num-executors", sparkConfig.getNumExecutors().toString());
+    addSparkArg(sparkLauncher, "--principal", sparkConfig.getPrincipal());
+    addSparkArg(sparkLauncher, "--keytab", sparkConfig.getKeytab());
+    sparkLauncher.setAppResource(sparkConfig.getAppResource());
+    sparkLauncher.setMainClass(mainClass);
+    Arrays.stream(args.split("\\s+"))
+        .filter(StringUtils::isNotBlank)
+        .forEach(arg -> sparkLauncher.addAppArgs(arg));
+    sparkAppHandle =
+        sparkLauncher.startApplication(
+            new SparkAppHandle.Listener() {
+              @Override
+              public void stateChanged(SparkAppHandle sparkAppHandle) {}
+
+              @Override
+              public void infoChanged(SparkAppHandle sparkAppHandle) {}
+            });
+    sparkLauncher.setSparkAppHandle(sparkAppHandle);
+  }
+
+  private void addSparkArg(SparkLauncher sparkLauncher, String key, String value) {
+    if (StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value)) {
+      sparkLauncher.addSparkArg(key, value);
+    }
+  }
+
+  private void setConf(SparkLauncher sparkLauncher, String key, String value) {
+    if (StringUtils.isNotBlank(key) && StringUtils.isNotBlank(value)) {
+      sparkLauncher.setConf(key, value);
+    }
+  }
+
+  public boolean initJobId() {
+    Pod sparkDriverPod = getSparkDriverPod();
+    if (null == sparkDriverPod) {
+      return false;
+    }
+    String sparkDriverPodPhase = sparkDriverPod.getStatus().getPhase();
+    String sparkApplicationId = sparkDriverPod.getMetadata().getLabels().get("spark-app-selector");
+
+    if (Strings.isNotBlank(sparkApplicationId)) {
+      this.applicationId = sparkApplicationId;
+    }
+    if (Strings.isNotBlank(sparkDriverPodPhase)) {
+      this.jobState = kubernetesPodStateConvertSparkState(sparkDriverPodPhase);
+    }
+
+    // When the job is not finished, the appId is monitored; otherwise, the status is
+    // monitored(当任务没结束时，监控appId，反之，则监控状态，这里主要防止任务过早结束，导致一直等待)
+    return null != getApplicationId() || (jobState != null && jobState.isFinal());
+  }
+
+  protected Pod getSparkDriverPod() {
+    return client.pods().inNamespace(namespace).withName(driverPodName).get();
+  }
+
+  public String getSparkDriverPodIP() {
+    Pod sparkDriverPod = getSparkDriverPod();
+    if (null != sparkDriverPod) {
+      String sparkDriverPodIP = sparkDriverPod.getStatus().getPodIP();
+      if (StringUtils.isNotBlank(sparkDriverPodIP)) {
+        return sparkDriverPodIP;
+      } else {
+        logger.info("spark driver pod IP is null, the application may be pending");
+      }
+    } else {
+      logger.info("spark driver pod is not exist");
+    }
+    return "";
+  }
+
+  @Override
+  public SparkAppHandle.State getJobState() {
+    Pod sparkDriverPod = getSparkDriverPod();
+    if (null != sparkDriverPod) {
+      String sparkDriverPodPhase = sparkDriverPod.getStatus().getPhase();
+      this.jobState = kubernetesPodStateConvertSparkState(sparkDriverPodPhase);
+      logger.info("Job {} state is {}.", getApplicationId(), this.jobState);
+      return this.jobState;
+    }
+    return null;
+  }
+
+  @Override
+  public void close() {
+    logger.info("Start to close job {}.", getApplicationId());
+    PodResource<Pod> sparkDriverPodResource =
+        client.pods().inNamespace(namespace).withName(driverPodName);
+    if (null != sparkDriverPodResource.get()) {
+      sparkDriverPodResource.delete();
+    }
+    client.close();
+  }
+
+  @Override
+  public boolean isDisposed() {
+    return this.jobState.isFinal();
+  }
+
+  public SparkAppHandle.State kubernetesPodStateConvertSparkState(String kubernetesState) {
+    if (StringUtils.isBlank(kubernetesState)) {
+      return SparkAppHandle.State.UNKNOWN;
+    }
+    switch (kubernetesState.toUpperCase()) {
+      case "PENDING":
+        return SparkAppHandle.State.CONNECTED;
+      case "RUNNING":
+        return SparkAppHandle.State.RUNNING;
+      case "SUCCEEDED":
+        return SparkAppHandle.State.FINISHED;
+      case "FAILED":
+        return SparkAppHandle.State.FAILED;
+      default:
+        return SparkAppHandle.State.UNKNOWN;
+    }
+  }
+}

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
@@ -30,6 +30,7 @@ import org.apache.spark.launcher.SparkLauncher;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -68,7 +69,7 @@ public class KubernetesApplicationClusterDescriptorAdapter extends ClusterDescri
         .setDeployMode(sparkConfig.getDeployMode())
         .setAppName(sparkConfig.getAppName())
         .setVerbose(true);
-    this.driverPodName = sparkConfig.getAppName() + "-" + System.currentTimeMillis() + "-driver";
+    this.driverPodName = generateDriverPodName(sparkConfig.getAppName());
     this.namespace = sparkConfig.getK8sNamespace();
     setConf(sparkLauncher, "spark.app.name", sparkConfig.getAppName());
     setConf(sparkLauncher, "spark.kubernetes.namespace", this.namespace);
@@ -222,5 +223,9 @@ public class KubernetesApplicationClusterDescriptorAdapter extends ClusterDescri
       default:
         return SparkAppHandle.State.UNKNOWN;
     }
+  }
+
+  public String generateDriverPodName(String appName) {
+    return appName + "-" + UUID.randomUUID().toString().replace("-", "") + "-driver";
   }
 }

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/KubernetesApplicationClusterDescriptorAdapter.java
@@ -60,10 +60,7 @@ public class KubernetesApplicationClusterDescriptorAdapter extends ClusterDescri
   public void deployCluster(String mainClass, String args, Map<String, String> confMap)
       throws IOException {
     SparkConfig sparkConfig = executionContext.getSparkConfig();
-    logger.info("===========SparkConfig: {}", sparkConfig);
-    logger.info("===========configMap: {}", confMap);
     sparkLauncher = new CustomSparkSubmitLauncher();
-    // region set args
     sparkLauncher
         .setJavaHome(sparkConfig.getJavaHome())
         .setSparkHome(sparkConfig.getSparkHome())

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkOnKubernetesSubmitOnceExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkOnKubernetesSubmitOnceExecutor.scala
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.executor
+
+import org.apache.linkis.common.utils.{ByteTimeUtils, Utils}
+import org.apache.linkis.engineconn.once.executor.{
+  OnceExecutorExecutionContext,
+  OperableOnceExecutor
+}
+import org.apache.linkis.engineplugin.spark.client.deployment.{
+  KubernetesApplicationClusterDescriptorAdapter,
+  YarnApplicationClusterDescriptorAdapter
+}
+import org.apache.linkis.engineplugin.spark.config.SparkConfiguration.{
+  SPARK_APP_CONF,
+  SPARK_APPLICATION_ARGS,
+  SPARK_APPLICATION_MAIN_CLASS
+}
+import org.apache.linkis.engineplugin.spark.context.SparkEngineConnContext
+import org.apache.linkis.engineplugin.spark.utils.SparkJobProgressUtil
+import org.apache.linkis.manager.common.entity.resource._
+import org.apache.linkis.manager.common.utils.ResourceUtils
+import org.apache.linkis.protocol.engine.JobProgressInfo
+
+import org.apache.commons.lang3.StringUtils
+
+import java.util
+
+import scala.concurrent.duration.Duration
+
+import io.fabric8.kubernetes.api.model.Quantity
+
+class SparkOnKubernetesSubmitOnceExecutor(
+    override val id: Long,
+    override protected val sparkEngineConnContext: SparkEngineConnContext
+) extends SparkOnceExecutor[KubernetesApplicationClusterDescriptorAdapter]
+    with OperableOnceExecutor {
+
+  private var oldProgress: Float = 0f
+
+  override def doSubmit(
+      onceExecutorExecutionContext: OnceExecutorExecutionContext,
+      options: Map[String, String]
+  ): Unit = {
+    logger.info("====================SparkOnKubernetesSubmitOnceExecutor option:{}", options)
+    val args = SPARK_APPLICATION_ARGS.getValue(options)
+    val mainClass = SPARK_APPLICATION_MAIN_CLASS.getValue(options)
+    val extConf = SPARK_APP_CONF.getValue(options)
+    val confMap = new util.HashMap[String, String]()
+    if (StringUtils.isNotBlank(extConf)) {
+      for (conf <- extConf.split("\n")) {
+        if (StringUtils.isNotBlank(conf)) {
+          val pair = conf.trim.split("=")
+          if (pair.length == 2) {
+            confMap.put(pair(0), pair(1))
+          } else {
+            logger.warn(s"ignore spark conf: $conf")
+          }
+        }
+      }
+    }
+    logger.info(s"Ready to submit spark application, mainClass: $mainClass, args: $args.")
+    clusterDescriptorAdapter.deployCluster(mainClass, args, confMap)
+  }
+
+  override protected def waitToRunning(): Unit = {
+    // Wait until the task return applicationId (等待返回applicationId)
+    Utils.waitUntil(() => clusterDescriptorAdapter.initJobId(), Duration.Inf)
+    // Synchronize applicationId to EC SparkOnceExecutor to facilitate user operations,
+    // such as obtaining progress and killing jobs(将applicationId同步给EC执行器，方便用户操作，如获取进度，kill任务等)
+    setApplicationId(clusterDescriptorAdapter.getApplicationId)
+    super.waitToRunning()
+  }
+
+  override def getApplicationURL: String = ""
+
+  override def getCurrentNodeResource(): NodeResource = {
+    logger.info("Begin to get actual used resources!")
+    Utils.tryCatch({
+      val sparkConf = sparkEngineConnContext.getExecutionContext.getSparkConfig
+      val sparkNamespace = sparkConf.getK8sNamespace
+
+      val executorNum: Int = sparkConf.getNumExecutors
+      val executorMem: Long =
+        ByteTimeUtils.byteStringAsBytes(sparkConf.getExecutorMemory) * executorNum
+      val driverMem: Long = ByteTimeUtils.byteStringAsBytes(sparkConf.getDriverMemory)
+
+      val executorCoresQuantity = Quantity.parse(sparkConf.getK8sExecutorRequestCores)
+      val executorCores: Long =
+        (Quantity.getAmountInBytes(executorCoresQuantity).doubleValue() * 1000).toLong * executorNum
+      val driverCoresQuantity = Quantity.parse(sparkConf.getK8sDriverRequestCores)
+      val driverCores: Long =
+        (Quantity.getAmountInBytes(driverCoresQuantity).doubleValue() * 1000).toLong
+
+      logger.info(
+        "Current actual used resources is driverMem:" + driverMem + ",driverCores:" + driverCores + ",executorMem:" + executorMem + ",executorCores:" + executorCores + ",namespace:" + sparkNamespace
+      )
+      val usedResource = new DriverAndKubernetesResource(
+        new LoadInstanceResource(0, 0, 0),
+        new KubernetesResource(executorMem + driverMem, executorCores + driverCores, sparkNamespace)
+      )
+      val nodeResource = new CommonNodeResource
+      nodeResource.setUsedResource(usedResource)
+      nodeResource.setResourceType(ResourceUtils.getResourceTypeByResource(usedResource))
+      nodeResource
+    })(t => {
+      logger.warn("Get actual used resource exception", t)
+      null
+    })
+  }
+
+  override def getProgress: Float = {
+    if (clusterDescriptorAdapter == null) {
+      logger.info("clusterDescriptorAdapter is null")
+    } else if (clusterDescriptorAdapter.getJobState == null) {
+      logger.info("clusterDescriptorAdapter.getJobState is null")
+    } else {
+      logger.info("clusterDescriptorAdapter/getJobState is not null")
+    }
+    val jobIsFinal = clusterDescriptorAdapter != null &&
+      clusterDescriptorAdapter.getJobState != null &&
+      clusterDescriptorAdapter.getJobState.isFinal
+    if (oldProgress >= 1 || jobIsFinal) {
+      1
+    } else {
+      val sparkDriverPodIP = this.clusterDescriptorAdapter.getSparkDriverPodIP
+      if (StringUtils.isNotBlank(sparkDriverPodIP)) {
+        val newProgress = SparkJobProgressUtil.getProgress(this.getApplicationId, sparkDriverPodIP)
+        if (newProgress > oldProgress) {
+          oldProgress = newProgress
+        }
+      }
+      oldProgress
+    }
+  }
+
+  override def getProgressInfo: Array[JobProgressInfo] = {
+    val sparkDriverPodIP = this.clusterDescriptorAdapter.getSparkDriverPodIP
+    if (StringUtils.isNotBlank(sparkDriverPodIP)) {
+      SparkJobProgressUtil.getSparkJobProgressInfo(this.getApplicationId, sparkDriverPodIP)
+    } else {
+      Array.empty
+    }
+  }
+
+  override def getMetrics: util.Map[String, Any] = {
+    new util.HashMap[String, Any]()
+  }
+
+  override def getDiagnosis: util.Map[String, Any] = {
+    new util.HashMap[String, Any]()
+  }
+
+}

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkOnKubernetesSubmitOnceExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkOnKubernetesSubmitOnceExecutor.scala
@@ -57,7 +57,6 @@ class SparkOnKubernetesSubmitOnceExecutor(
       onceExecutorExecutionContext: OnceExecutorExecutionContext,
       options: Map[String, String]
   ): Unit = {
-    logger.info("====================SparkOnKubernetesSubmitOnceExecutor option:{}", options)
     val args = SPARK_APPLICATION_ARGS.getValue(options)
     val mainClass = SPARK_APPLICATION_MAIN_CLASS.getValue(options)
     val extConf = SPARK_APP_CONF.getValue(options)
@@ -74,7 +73,9 @@ class SparkOnKubernetesSubmitOnceExecutor(
         }
       }
     }
-    logger.info(s"Ready to submit spark application, mainClass: $mainClass, args: $args.")
+    logger.info(
+      s"Ready to submit spark application to kubernetes, mainClass: $mainClass, args: $args."
+    )
     clusterDescriptorAdapter.deployCluster(mainClass, args, confMap)
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkOnKubernetesSubmitOnceExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkOnKubernetesSubmitOnceExecutor.scala
@@ -126,13 +126,6 @@ class SparkOnKubernetesSubmitOnceExecutor(
   }
 
   override def getProgress: Float = {
-    if (clusterDescriptorAdapter == null) {
-      logger.info("clusterDescriptorAdapter is null")
-    } else if (clusterDescriptorAdapter.getJobState == null) {
-      logger.info("clusterDescriptorAdapter.getJobState is null")
-    } else {
-      logger.info("clusterDescriptorAdapter/getJobState is not null")
-    }
     val jobIsFinal = clusterDescriptorAdapter != null &&
       clusterDescriptorAdapter.getJobState != null &&
       clusterDescriptorAdapter.getJobState.isFinal

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkEngineConnFactory.scala
@@ -109,6 +109,8 @@ class SparkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
       sparkConfig.setK8sRestartPolicy(SPARK_K8S_RESTART_POLICY.getValue(options))
       sparkConfig.setK8sLanguageType(SPARK_K8S_LANGUAGE_TYPE.getValue(options))
       sparkConfig.setK8sImagePullPolicy(SPARK_K8S_IMAGE_PULL_POLICY.getValue(options))
+      sparkConfig.setK8sDriverRequestCores(SPARK_K8S_DRIVER_REQUEST_CORES.getValue(options))
+      sparkConfig.setK8sExecutorRequestCores(SPARK_K8S_EXECUTOR_REQUEST_CORES.getValue(options))
     }
     sparkConfig.setDeployMode(SPARK_DEPLOY_MODE.getValue(options))
     sparkConfig.setAppResource(SPARK_APP_RESOURCE.getValue(options))

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkEngineConnResourceFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkEngineConnResourceFactory.scala
@@ -113,7 +113,9 @@ class SparkEngineConnResourceFactory extends AbstractEngineResourceFactory with 
         Quantity.parse(SPARK_K8S_EXECUTOR_REQUEST_CORES.getValue(properties))
       (Quantity.getAmountInBytes(executorCoresQuantity).doubleValue() * 1000).toLong
     } else {
-      LINKIS_SPARK_EXECUTOR_CORES.getValue(properties) * 1000L
+      val sparkDefaultExecutorCores: Int = LINKIS_SPARK_EXECUTOR_CORES.getValue(properties)
+      properties.put(SPARK_K8S_EXECUTOR_REQUEST_CORES.key, sparkDefaultExecutorCores.toString)
+      sparkDefaultExecutorCores * 1000L
     }
     val executorMemory = LINKIS_SPARK_EXECUTOR_MEMORY.getValue(properties)
     val executorMemoryWithUnit = if (StringUtils.isNumeric(executorMemory)) {
@@ -126,7 +128,9 @@ class SparkEngineConnResourceFactory extends AbstractEngineResourceFactory with 
         Quantity.parse(SPARK_K8S_DRIVER_REQUEST_CORES.getValue(properties))
       (Quantity.getAmountInBytes(executorCoresQuantity).doubleValue() * 1000).toLong
     } else {
-      LINKIS_SPARK_DRIVER_CORES.getValue(properties) * 1000L
+      val sparkDefaultDriverCores: Int = LINKIS_SPARK_DRIVER_CORES.getValue(properties)
+      properties.put(SPARK_K8S_DRIVER_REQUEST_CORES.key, sparkDefaultDriverCores.toString)
+      sparkDefaultDriverCores * 1000L
     }
     val driverMemory = LINKIS_SPARK_DRIVER_MEMORY.getValue(properties)
     val driverMemoryWithUnit = if (StringUtils.isNumeric(driverMemory)) {

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkOnceExecutorFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkOnceExecutorFactory.scala
@@ -42,9 +42,6 @@ class SparkOnceExecutorFactory extends OnceExecutorFactory {
       labels: Array[Label[_]]
   ): OnceExecutor = {
     val clusterLabel = LabelUtil.getLabelFromArray[ClusterLabel](labels)
-    logger.info("=========engineCreationContext:{}", engineCreationContext.getOptions)
-    logger.info("=========engineConn:{}", engineConn)
-    logger.info("=========label:{}", clusterLabel)
     engineConn.getEngineConnSession match {
       case context: SparkEngineConnContext
           if null != clusterLabel && clusterLabel.getClusterType.equalsIgnoreCase(

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkOnceExecutorFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkOnceExecutorFactory.scala
@@ -43,13 +43,16 @@ class SparkOnceExecutorFactory extends OnceExecutorFactory {
   ): OnceExecutor = {
     val clusterLabel = LabelUtil.getLabelFromArray[ClusterLabel](labels)
     engineConn.getEngineConnSession match {
-      case context: SparkEngineConnContext
-          if null != clusterLabel && clusterLabel.getClusterType.equalsIgnoreCase(
-            DEFAULT_KUBERNETES_TYPE.getValue
-          ) =>
-        new SparkOnKubernetesSubmitOnceExecutor(id, context)
       case context: SparkEngineConnContext =>
-        new SparkSubmitOnceExecutor(id, context)
+        if (
+            null != clusterLabel && clusterLabel.getClusterType.equalsIgnoreCase(
+              DEFAULT_KUBERNETES_TYPE.getValue
+            )
+        ) {
+          new SparkOnKubernetesSubmitOnceExecutor(id, context)
+        } else {
+          new SparkSubmitOnceExecutor(id, context)
+        }
     }
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkOnceExecutorFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkOnceExecutorFactory.scala
@@ -22,10 +22,16 @@ import org.apache.linkis.engineconn.common.engineconn.EngineConn
 import org.apache.linkis.engineconn.once.executor.OnceExecutor
 import org.apache.linkis.engineconn.once.executor.creation.OnceExecutorFactory
 import org.apache.linkis.engineplugin.spark.context.SparkEngineConnContext
-import org.apache.linkis.engineplugin.spark.executor.SparkSubmitOnceExecutor
+import org.apache.linkis.engineplugin.spark.executor.{
+  SparkOnKubernetesSubmitOnceExecutor,
+  SparkSubmitOnceExecutor
+}
+import org.apache.linkis.manager.common.conf.RMConfiguration.DEFAULT_KUBERNETES_TYPE
 import org.apache.linkis.manager.label.entity.Label
+import org.apache.linkis.manager.label.entity.cluster.ClusterLabel
 import org.apache.linkis.manager.label.entity.engine.RunType
 import org.apache.linkis.manager.label.entity.engine.RunType.RunType
+import org.apache.linkis.manager.label.utils.LabelUtil
 
 class SparkOnceExecutorFactory extends OnceExecutorFactory {
 
@@ -34,11 +40,21 @@ class SparkOnceExecutorFactory extends OnceExecutorFactory {
       engineCreationContext: EngineCreationContext,
       engineConn: EngineConn,
       labels: Array[Label[_]]
-  ): OnceExecutor =
+  ): OnceExecutor = {
+    val clusterLabel = LabelUtil.getLabelFromArray[ClusterLabel](labels)
+    logger.info("=========engineCreationContext:{}", engineCreationContext.getOptions)
+    logger.info("=========engineConn:{}", engineConn)
+    logger.info("=========label:{}", clusterLabel)
     engineConn.getEngineConnSession match {
+      case context: SparkEngineConnContext
+          if null != clusterLabel && clusterLabel.getClusterType.equalsIgnoreCase(
+            DEFAULT_KUBERNETES_TYPE.getValue
+          ) =>
+        new SparkOnKubernetesSubmitOnceExecutor(id, context)
       case context: SparkEngineConnContext =>
         new SparkSubmitOnceExecutor(id, context)
     }
+  }
 
   override protected def getRunType: RunType = RunType.JAR
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

Support submit spark jar job on k8s.

### Environment
Spark：v3.2.1
Kubernetes: v1.23
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.5", GitCommit:"c285e781331a3785a7f436042c65c5641ce8a9e9", GitTreeState:"clean", BuildDate:"2022-03-16T15:58:47Z", GoVersion:"go1.17.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.17", GitCommit:"953be8927218ec8067e1af2641e540238ffd7576", GitTreeState:"clean", BuildDate:"2023-02-22T13:27:46Z", GoVersion:"go1.19.6", Compiler:"gc", Platform:"linux/amd64"}
```
Linkis：
![image](https://github.com/apache/linkis/assets/66543456/434fbc4a-25db-4f7f-bb56-1da214f90993)



### Test Command
```
linkis-cli --mode once \
-code 'sparkjars' \
-engineType spark-3.2.1 \
-codeType jar \
-labelMap engineConnMode=once \
-sourceMap jobName=OnceJobTest \
-k8sCluster 'K8S-default' \
-jobContentMap spark.app.main.class='org.apache.spark.examples.SparkPi' \
-jobContentMap runType='jar' \
-confMap spark.master='k8s-native' \
-confMap linkis.spark.k8s.serviceAccount='spark' \
-confMap spark.submit.deployMode='cluster' \
-confMap linkis.spark.k8s.master.url='k8s://https://172.31.226.155:6443' \
-confMap linkis.spark.k8s.config.file='/home/hadoop/.kube/config' \
-confMap linkis.spark.k8s.imagePullPolicy='IfNotPresent' \
-confMap spark.app.name='spark-submit-jar-k8s-test-linkis' \
-confMap spark.app.resource='local:///opt/spark/examples/jars/spark-examples_2.12-3.2.1.jar' \
-confMap linkis.spark.k8s.namespace='default'
```

### Brief change log

- SparkConfig.java: add `spark.kubernetes.driver.request.cores` and `spark.kubernetes.executor.request.cores` related fields.
- ClusterDescriptorAdapterFactory.java: add new k8s submission way("`k8s-native`", different from "`k8s-operator`").
- KubernetesApplicationClusterDescriptorAdapter.java: main features are as below
    - SparkLauncher add k8s related params setting.
    - Manually specifying driver pod name for follow-up task monitoring.
    - `initJobId()` method converts the state of the driver pod to the `SparkAppHandle.State` to determine whether the task has started.
- SparkOnKubernetesSubmitOnceExecutor.scala: new once executor type for k8s.
- SparkEngineConnFactory.scala: add `linkis.spark.k8s.driver.request.cores` and `linkis.spark.k8s.executor.request.cores` to sparkConf.
- SparkEngineConnResourceFactory.scala: According to [Spark Doc](https://spark.apache.org/docs/latest/running-on-kubernetes.html#configuration) , `spark.kubernetes.executor.request.cores` and `spark.kubernetes.driver.request.cores` have priority over `spark.executor.cores` and `spark.driver.cores`. So if `spark.kubernetes.executor.request.cores` is not specified when check resources, manually assign the value of `spark.executor.cores` to `spark.kubernetes.executor.request.cores` to make sure the default value of `spark.kubernetes.executor.request.cores` won't affect the tasks.
![ca39e93103aa05ce81391ef3f8566c6](https://github.com/apache/linkis/assets/66543456/09b85919-b22b-48f4-b71c-846111f03e17)

- SparkOnceExecutorFactory.scala: Create `SparkOnKubernetesSubmitOnceExecutor` if `-k8sCluster` is specified.
- SparkJobProgressUtil.scala: main features are as below
    - Methods add `podIP` params to be compatible with the spark tasks on k8s.
    - `getKubernetesSparkJobInfo()`: method for getting status of spark tasks through Spark UI exposed on driver pod’s 4040 port.


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
