### PR TITLE
scriptis left database menu bar supports hiveserver2 to get library table fields

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/pom.xml
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/pom.xml
@@ -95,6 +95,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-jdbc</artifactId>
+      <version>${hive.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/DWSConfig.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/DWSConfig.java
@@ -49,4 +49,16 @@ public class DWSConfig {
               "wds.linkis.hdfs.rest.errs",
               ".*Filesystem closed.*|.*Failed to find any Kerberos tgt.*")
           .getValue();
+
+  public static CommonVars<String> HIVE_SERVER2_URL =
+      CommonVars$.MODULE$.apply("linkis.hive.server2.address", "jdbc:hive2://127.0.0.1:10000/");
+
+  public static CommonVars<String> HIVE_SERVER2_USERNAME =
+      CommonVars$.MODULE$.apply("linkis.hive.server2.username", "");
+
+  public static CommonVars<String> HIVE_SERVER2_PASSWORD =
+      CommonVars$.MODULE$.apply("linkis.hive.server2.password", "");
+
+  public static CommonVars<Boolean> HIVE_SERVER2_ENABLE =
+      CommonVars$.MODULE$.apply("linkis.hive.server2.enable", false);
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/DWSConfig.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/DWSConfig.java
@@ -53,12 +53,6 @@ public class DWSConfig {
   public static CommonVars<String> HIVE_SERVER2_URL =
       CommonVars$.MODULE$.apply("linkis.hive.server2.address", "jdbc:hive2://127.0.0.1:10000/");
 
-  public static CommonVars<String> HIVE_SERVER2_USERNAME =
-      CommonVars$.MODULE$.apply("linkis.hive.server2.username", "");
-
-  public static CommonVars<String> HIVE_SERVER2_PASSWORD =
-      CommonVars$.MODULE$.apply("linkis.hive.server2.password", "");
-
   public static CommonVars<Boolean> HIVE_SERVER2_ENABLE =
       CommonVars$.MODULE$.apply("linkis.hive.server2.enable", false);
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.metadata.util;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.sql.*;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/** @author Qin* */
+public class HiveService2Utils {
+
+  private static final String driverName = "org.apache.hive.jdbc.HiveDriver";
+
+  private static final String defaultDb = "default";
+  private static Connection conn = null;
+  private static Statement stat = null;
+  private static ResultSet rs = null;
+
+  static ObjectMapper jsonMapper = new ObjectMapper();
+  static SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US);
+
+  /** 判断是否启动hiveServer2查询左侧菜单栏 */
+  public static Boolean checkHiveServer2Enable() {
+    return DWSConfig.HIVE_SERVER2_ENABLE.getValue();
+  }
+
+  static String hiveServer2Address = DWSConfig.HIVE_SERVER2_URL.getValue();
+  static String hiveServer2Username = DWSConfig.HIVE_SERVER2_USERNAME.getValue();
+  static String hiveServer2Password = DWSConfig.HIVE_SERVER2_PASSWORD.getValue();
+
+  /**
+   * 获取链接
+   *
+   * @param username 用户名
+   */
+  private static void getConn(String username, String db) throws Exception {
+    Class.forName(driverName);
+    String url =
+        hiveServer2Address.endsWith("/") ? hiveServer2Address + db : hiveServer2Address + "/" + db;
+    if (StringUtils.isNotBlank(hiveServer2Username)) {
+      username = hiveServer2Username;
+    }
+    conn = DriverManager.getConnection(url, username, hiveServer2Password);
+    stat = conn.createStatement();
+  }
+
+  /** 获取数据库 */
+  public static JsonNode getDbs(String username) throws Exception {
+    ArrayNode dbsNode = jsonMapper.createArrayNode();
+    List<String> dbs = new CopyOnWriteArrayList<>();
+    try {
+      getConn(username, defaultDb);
+      rs = stat.executeQuery("show databases");
+      while (rs.next()) {
+        dbs.add(rs.getString(1));
+      }
+    } finally {
+      destroy();
+    }
+    for (String db : dbs) {
+      ObjectNode dbNode = jsonMapper.createObjectNode();
+      dbNode.put("dbName", db);
+      dbsNode.add(dbNode);
+    }
+    return dbsNode;
+  }
+
+  /**
+   * 获取指定数据库的所有表
+   *
+   * @param dbName 数据库
+   */
+  public static JsonNode getTables(String username, String dbName) throws Exception {
+    ArrayNode tablesNode = jsonMapper.createArrayNode();
+    try {
+      List<String> tableNames = new ArrayList<>();
+      getConn(username, dbName);
+      rs = stat.executeQuery("show tables");
+      while (rs.next()) {
+        String tableName = rs.getString(1);
+        tableNames.add(tableName);
+      }
+
+      //  获取每个表的详细信息
+      for (String tableName : tableNames) {
+        ObjectNode tableNode = jsonMapper.createObjectNode();
+        // 获取表详细信息
+        ResultSet describeRs = stat.executeQuery("DESCRIBE FORMATTED " + tableName);
+        while (describeRs.next()) {
+          String columnName = describeRs.getString(1);
+          String dataType = describeRs.getString(2);
+          if (null != columnName) {
+            columnName = columnName.trim();
+          }
+          if (null != dataType) {
+            dataType = dataType.trim();
+          }
+          if (columnName.contains("Owner:")) {
+            tableNode.put("createdBy", dataType);
+          }
+          if (columnName.contains("CreateTime:")) {
+            long createdAt = sdf.parse(dataType).getTime() / 1000;
+            tableNode.put("createdAt", createdAt);
+            break;
+          }
+        }
+        describeRs.close();
+        tableNode.put("databaseName", dbName);
+        tableNode.put("tableName", tableName);
+        tableNode.put("lastAccessAt", 0);
+        tableNode.put("isView", false);
+        tablesNode.add(tableNode);
+      }
+    } finally {
+      destroy();
+    }
+
+    return tablesNode;
+  }
+
+  /**
+   * 获取指定表所有字段信息
+   *
+   * @param dbName 数据库
+   * @param tbName 数据表
+   */
+  public static JsonNode getColumns(String username, String dbName, String tbName)
+      throws Exception {
+    ArrayNode columnsNode = jsonMapper.createArrayNode();
+    List<Map<String, Object>> columnMapList = new ArrayList<>();
+    List<String> partitionColumnList = new ArrayList<>();
+    try {
+      getConn(username, dbName);
+      rs = stat.executeQuery("desc " + tbName);
+      while (rs.next()) {
+        Map<String, Object> colum = new HashMap<>();
+        String colName = rs.getString("col_name");
+        String dataType = rs.getString("data_type");
+        if (StringUtils.isNotBlank(colName)
+            && StringUtils.isNotBlank(dataType)
+            && !colName.contains("# Partition Information")
+            && !colName.contains("# col_name")) {
+          colum.put("columnName", rs.getString("col_name"));
+          colum.put("columnType", rs.getString("data_type"));
+          colum.put("columnComment", rs.getString("comment"));
+          columnMapList.add(colum);
+        }
+      }
+
+      boolean partition = false;
+      boolean parColName = false;
+      ResultSet describeRs = stat.executeQuery("DESCRIBE FORMATTED " + tbName);
+      while (describeRs.next()) {
+        String columnName = describeRs.getString(1);
+        String dataType = describeRs.getString(2);
+        if (null != columnName) {
+          columnName = columnName.trim();
+        }
+        if (null != dataType) {
+          dataType = dataType.trim();
+        }
+
+        // 判断获取分区字段
+        if (columnName.contains("# Partition Information")) {
+          partition = true;
+          parColName = false;
+          continue;
+        }
+        if (columnName.contains("# col_name")) {
+          parColName = true;
+          continue;
+        }
+
+        if (partition && parColName) {
+          if ("".equals(columnName) && null == dataType) {
+            partition = false;
+            parColName = false;
+          } else {
+            partitionColumnList.add(columnName);
+          }
+        }
+      }
+      describeRs.close();
+    } finally {
+      destroy();
+    }
+
+    for (Map<String, Object> map : columnMapList.stream().distinct().collect(Collectors.toList())) {
+      ObjectNode fieldNode = jsonMapper.createObjectNode();
+      String columnName = map.get("columnName").toString();
+      fieldNode.put("columnName", columnName);
+      fieldNode.put("columnType", map.get("columnType").toString());
+      fieldNode.put("columnComment", map.get("columnComment").toString());
+      fieldNode.put("partitioned", partitionColumnList.contains(columnName));
+      columnsNode.add(fieldNode);
+    }
+
+    return columnsNode;
+  }
+
+  // 释放资源
+  private static void destroy() throws SQLException {
+    if (rs != null) {
+      rs.close();
+    }
+    if (stat != null) {
+      stat.close();
+    }
+    if (conn != null) {
+      conn.close();
+    }
+  }
+}

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
@@ -179,6 +179,7 @@ public class HiveService2Utils {
           dataType = dataType.trim();
         }
 
+        // Partition field judgment
         if (columnName.contains("# Partition Information")) {
           partition = true;
           parColName = false;

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
@@ -20,16 +20,16 @@ package org.apache.linkis.metadata.util;
 import org.apache.commons.lang.StringUtils;
 
 import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
 import java.sql.DriverManager;
-import java.util.Locale;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
+import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
+import java.sql.Statement;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -39,207 +39,195 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class HiveService2Utils {
 
-    private static final String driverName = "org.apache.hive.jdbc.HiveDriver";
+  private static final String driverName = "org.apache.hive.jdbc.HiveDriver";
 
-    private static final String defaultDb = "default";
-    private static final String defaultPassword = "123456";
+  private static final String defaultDb = "default";
+  private static final String defaultPassword = "123456";
 
-    static ObjectMapper jsonMapper = new ObjectMapper();
-    static SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US);
+  static ObjectMapper jsonMapper = new ObjectMapper();
+  static SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US);
 
-    /**
-     * Determine whether to start hiveServer2 Query the left menu bar
-     */
-    public static Boolean checkHiveServer2Enable() {
-        return DWSConfig.HIVE_SERVER2_ENABLE.getValue();
+  /** Determine whether to start hiveServer2 Query the left menu bar */
+  public static Boolean checkHiveServer2Enable() {
+    return DWSConfig.HIVE_SERVER2_ENABLE.getValue();
+  }
+
+  /** Get connection */
+  private static Connection getConn(String username, String db) throws Exception {
+    Class.forName(driverName);
+    String hiveServer2Address = DWSConfig.HIVE_SERVER2_URL.getValue();
+    String url =
+        hiveServer2Address.endsWith("/") ? hiveServer2Address + db : hiveServer2Address + "/" + db;
+    return DriverManager.getConnection(url, username, defaultPassword);
+  }
+
+  /** Get database */
+  public static JsonNode getDbs(String username) throws Exception {
+    ArrayNode dbsNode = jsonMapper.createArrayNode();
+    List<String> dbs = new ArrayList<>();
+    Connection conn = null;
+    Statement stat = null;
+    ResultSet rs = null;
+    try {
+      conn = getConn(username, defaultDb);
+      stat = conn.createStatement();
+      rs = stat.executeQuery("show databases");
+      while (rs.next()) {
+        dbs.add(rs.getString(1));
+      }
+    } finally {
+      close(conn, stat, rs);
+    }
+    for (String db : dbs) {
+      ObjectNode dbNode = jsonMapper.createObjectNode();
+      dbNode.put("dbName", db);
+      dbsNode.add(dbNode);
+    }
+    return dbsNode;
+  }
+
+  /** Gets all tables for the specified database */
+  public static JsonNode getTables(String username, String dbName) throws Exception {
+    ArrayNode tablesNode = jsonMapper.createArrayNode();
+    Connection conn = null;
+    Statement stat = null;
+    ResultSet rs = null;
+    try {
+      List<String> tableNames = new ArrayList<>();
+      conn = getConn(username, dbName);
+      stat = conn.createStatement();
+      rs = stat.executeQuery("show tables");
+      while (rs.next()) {
+        String tableName = rs.getString(1);
+        tableNames.add(tableName);
+      }
+
+      //  获取每个表的详细信息
+      for (String tableName : tableNames) {
+        ObjectNode tableNode = jsonMapper.createObjectNode();
+        // 获取表详细信息
+        ResultSet describeRs = stat.executeQuery("DESCRIBE FORMATTED " + tableName);
+        while (describeRs.next()) {
+          String columnName = describeRs.getString(1);
+          String dataType = describeRs.getString(2);
+          if (null != columnName) {
+            columnName = columnName.trim();
+          }
+          if (null != dataType) {
+            dataType = dataType.trim();
+          }
+          if (columnName.contains("Owner:")) {
+            tableNode.put("createdBy", dataType);
+          }
+          if (columnName.contains("CreateTime:")) {
+            long createdAt = sdf.parse(dataType).getTime() / 1000;
+            tableNode.put("createdAt", createdAt);
+            break;
+          }
+        }
+        describeRs.close();
+        tableNode.put("databaseName", dbName);
+        tableNode.put("tableName", tableName);
+        tableNode.put("lastAccessAt", 0);
+        tableNode.put("isView", false);
+        tablesNode.add(tableNode);
+      }
+    } finally {
+      close(conn, stat, rs);
     }
 
-    /**
-     * Get connection
-     */
-    private static Connection getConn(String username, String db) throws Exception {
-        Class.forName(driverName);
-        String hiveServer2Address = DWSConfig.HIVE_SERVER2_URL.getValue();
-        String url =
-                hiveServer2Address.endsWith("/") ? hiveServer2Address + db : hiveServer2Address + "/" + db;
-        return DriverManager.getConnection(url, username, defaultPassword);
+    return tablesNode;
+  }
+
+  /** Gets information about all fields of a specified table */
+  public static JsonNode getColumns(String username, String dbName, String tbName)
+      throws Exception {
+    ArrayNode columnsNode = jsonMapper.createArrayNode();
+    List<Map<String, Object>> columnMapList = new ArrayList<>();
+    List<String> partitionColumnList = new ArrayList<>();
+    Connection conn = null;
+    Statement stat = null;
+    ResultSet rs = null;
+    try {
+      conn = getConn(username, dbName);
+      stat = conn.createStatement();
+      rs = stat.executeQuery("desc " + tbName);
+      while (rs.next()) {
+        Map<String, Object> colum = new HashMap<>();
+        String colName = rs.getString("col_name");
+        String dataType = rs.getString("data_type");
+        if (StringUtils.isNotBlank(colName)
+            && StringUtils.isNotBlank(dataType)
+            && !colName.contains("# Partition Information")
+            && !colName.contains("# col_name")) {
+          colum.put("columnName", rs.getString("col_name"));
+          colum.put("columnType", rs.getString("data_type"));
+          colum.put("columnComment", rs.getString("comment"));
+          columnMapList.add(colum);
+        }
+      }
+
+      boolean partition = false;
+      boolean parColName = false;
+      ResultSet describeRs = stat.executeQuery("DESCRIBE FORMATTED " + tbName);
+      while (describeRs.next()) {
+        String columnName = describeRs.getString(1);
+        String dataType = describeRs.getString(2);
+        if (null != columnName) {
+          columnName = columnName.trim();
+        }
+        if (null != dataType) {
+          dataType = dataType.trim();
+        }
+
+        // 判断获取分区字段
+        if (columnName.contains("# Partition Information")) {
+          partition = true;
+          parColName = false;
+          continue;
+        }
+        if (columnName.contains("# col_name")) {
+          parColName = true;
+          continue;
+        }
+
+        if (partition && parColName) {
+          if ("".equals(columnName) && null == dataType) {
+            partition = false;
+            parColName = false;
+          } else {
+            partitionColumnList.add(columnName);
+          }
+        }
+      }
+      describeRs.close();
+    } finally {
+      close(conn, stat, rs);
     }
 
-    /**
-     * Get database
-     */
-    public static JsonNode getDbs(String username) throws Exception {
-        ArrayNode dbsNode = jsonMapper.createArrayNode();
-        List<String> dbs = new ArrayList<>();
-        Connection conn = null;
-        Statement stat = null;
-        ResultSet rs = null;
-        try {
-            conn = getConn(username, defaultDb);
-            stat = conn.createStatement();
-            rs = stat.executeQuery("show databases");
-            while (rs.next()) {
-                dbs.add(rs.getString(1));
-            }
-        } finally {
-            close(conn, stat, rs);
-        }
-        for (String db : dbs) {
-            ObjectNode dbNode = jsonMapper.createObjectNode();
-            dbNode.put("dbName", db);
-            dbsNode.add(dbNode);
-        }
-        return dbsNode;
+    for (Map<String, Object> map : columnMapList.stream().distinct().collect(Collectors.toList())) {
+      ObjectNode fieldNode = jsonMapper.createObjectNode();
+      String columnName = map.get("columnName").toString();
+      fieldNode.put("columnName", columnName);
+      fieldNode.put("columnType", map.get("columnType").toString());
+      fieldNode.put("columnComment", map.get("columnComment").toString());
+      fieldNode.put("partitioned", partitionColumnList.contains(columnName));
+      columnsNode.add(fieldNode);
     }
 
-    /**
-     * Gets all tables for the specified database
-     */
-    public static JsonNode getTables(String username, String dbName) throws Exception {
-        ArrayNode tablesNode = jsonMapper.createArrayNode();
-        Connection conn = null;
-        Statement stat = null;
-        ResultSet rs = null;
-        try {
-            List<String> tableNames = new ArrayList<>();
-            conn = getConn(username, dbName);
-            stat = conn.createStatement();
-            rs = stat.executeQuery("show tables");
-            while (rs.next()) {
-                String tableName = rs.getString(1);
-                tableNames.add(tableName);
-            }
+    return columnsNode;
+  }
 
-            //  获取每个表的详细信息
-            for (String tableName : tableNames) {
-                ObjectNode tableNode = jsonMapper.createObjectNode();
-                // 获取表详细信息
-                ResultSet describeRs = stat.executeQuery("DESCRIBE FORMATTED " + tableName);
-                while (describeRs.next()) {
-                    String columnName = describeRs.getString(1);
-                    String dataType = describeRs.getString(2);
-                    if (null != columnName) {
-                        columnName = columnName.trim();
-                    }
-                    if (null != dataType) {
-                        dataType = dataType.trim();
-                    }
-                    if (columnName.contains("Owner:")) {
-                        tableNode.put("createdBy", dataType);
-                    }
-                    if (columnName.contains("CreateTime:")) {
-                        long createdAt = sdf.parse(dataType).getTime() / 1000;
-                        tableNode.put("createdAt", createdAt);
-                        break;
-                    }
-                }
-                describeRs.close();
-                tableNode.put("databaseName", dbName);
-                tableNode.put("tableName", tableName);
-                tableNode.put("lastAccessAt", 0);
-                tableNode.put("isView", false);
-                tablesNode.add(tableNode);
-            }
-        } finally {
-            close(conn, stat, rs);
-        }
-
-        return tablesNode;
+  /** Close resource */
+  private static void close(Connection conn, Statement stat, ResultSet rs) throws SQLException {
+    if (rs != null) {
+      rs.close();
     }
-
-    /**
-     * Gets information about all fields of a specified table
-     */
-    public static JsonNode getColumns(String username, String dbName, String tbName)
-            throws Exception {
-        ArrayNode columnsNode = jsonMapper.createArrayNode();
-        List<Map<String, Object>> columnMapList = new ArrayList<>();
-        List<String> partitionColumnList = new ArrayList<>();
-        Connection conn = null;
-        Statement stat = null;
-        ResultSet rs = null;
-        try {
-            conn = getConn(username, dbName);
-            stat = conn.createStatement();
-            rs = stat.executeQuery("desc " + tbName);
-            while (rs.next()) {
-                Map<String, Object> colum = new HashMap<>();
-                String colName = rs.getString("col_name");
-                String dataType = rs.getString("data_type");
-                if (StringUtils.isNotBlank(colName)
-                        && StringUtils.isNotBlank(dataType)
-                        && !colName.contains("# Partition Information")
-                        && !colName.contains("# col_name")) {
-                    colum.put("columnName", rs.getString("col_name"));
-                    colum.put("columnType", rs.getString("data_type"));
-                    colum.put("columnComment", rs.getString("comment"));
-                    columnMapList.add(colum);
-                }
-            }
-
-            boolean partition = false;
-            boolean parColName = false;
-            ResultSet describeRs = stat.executeQuery("DESCRIBE FORMATTED " + tbName);
-            while (describeRs.next()) {
-                String columnName = describeRs.getString(1);
-                String dataType = describeRs.getString(2);
-                if (null != columnName) {
-                    columnName = columnName.trim();
-                }
-                if (null != dataType) {
-                    dataType = dataType.trim();
-                }
-
-                // 判断获取分区字段
-                if (columnName.contains("# Partition Information")) {
-                    partition = true;
-                    parColName = false;
-                    continue;
-                }
-                if (columnName.contains("# col_name")) {
-                    parColName = true;
-                    continue;
-                }
-
-                if (partition && parColName) {
-                    if ("".equals(columnName) && null == dataType) {
-                        partition = false;
-                        parColName = false;
-                    } else {
-                        partitionColumnList.add(columnName);
-                    }
-                }
-            }
-            describeRs.close();
-        } finally {
-            close(conn, stat, rs);
-        }
-
-        for (Map<String, Object> map : columnMapList.stream().distinct().collect(Collectors.toList())) {
-            ObjectNode fieldNode = jsonMapper.createObjectNode();
-            String columnName = map.get("columnName").toString();
-            fieldNode.put("columnName", columnName);
-            fieldNode.put("columnType", map.get("columnType").toString());
-            fieldNode.put("columnComment", map.get("columnComment").toString());
-            fieldNode.put("partitioned", partitionColumnList.contains(columnName));
-            columnsNode.add(fieldNode);
-        }
-
-        return columnsNode;
+    if (stat != null) {
+      stat.close();
     }
-
-    /**
-     * Close resource
-     */
-    private static void close(Connection conn, Statement stat, ResultSet rs) throws SQLException {
-        if (rs != null) {
-            rs.close();
-        }
-        if (stat != null) {
-            stat.close();
-        }
-        if (conn != null) {
-            conn.close();
-        }
+    if (conn != null) {
+      conn.close();
     }
+  }
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
@@ -179,7 +179,6 @@ public class HiveService2Utils {
           dataType = dataType.trim();
         }
 
-        // Judgment Get partition field
         if (columnName.contains("# Partition Information")) {
           partition = true;
           parColName = false;

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/util/HiveService2Utils.java
@@ -102,10 +102,9 @@ public class HiveService2Utils {
         tableNames.add(tableName);
       }
 
-      //  获取每个表的详细信息
+      //  Get detailed information about each table
       for (String tableName : tableNames) {
         ObjectNode tableNode = jsonMapper.createObjectNode();
-        // 获取表详细信息
         ResultSet describeRs = stat.executeQuery("DESCRIBE FORMATTED " + tableName);
         while (describeRs.next()) {
           String columnName = describeRs.getString(1);
@@ -180,7 +179,7 @@ public class HiveService2Utils {
           dataType = dataType.trim();
         }
 
-        // 判断获取分区字段
+        // Judgment Get partition field
         if (columnName.contains("# Partition Information")) {
           partition = true;
           parColName = false;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

The left database menu bar of scriptis supports hiveserver2 to get library table fields, which is off by default
Related parameters:
To enable this function, you need to add the following configuration in the linkis-ps-publicservice. properties file
Enable hiveserver2 access: linkis.hive.server2.enable=true
Configuration hiveserver2 address: linkis.hive.server2.address=jdbc:hive2://127.0.0.1:10000/

