### PR TITLE
[BUG] Fix em sort error

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/selector/rule/ResourceNodeSelectRule.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/selector/rule/ResourceNodeSelectRule.java
@@ -53,10 +53,10 @@ public class ResourceNodeSelectRule implements NodeSelectRule {
           RMNode nodeBRm = (RMNode) nodeB;
           if (nodeARm.getNodeResource() == null
               || nodeARm.getNodeResource().getLeftResource() == null) {
-            return -1;
+            return 1;
           } else if (nodeBRm.getNodeResource() == null
               || nodeBRm.getNodeResource().getLeftResource() == null) {
-            return 1;
+            return -1;
           } else {
             if (nodeARm
                 .getNodeResource()

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/selector/rule/ResourceNodeSelectRule.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/selector/rule/ResourceNodeSelectRule.java
@@ -69,7 +69,11 @@ public class ResourceNodeSelectRule implements NodeSelectRule {
                 .moreThan(nodeBRm.getNodeResource().getLeftResource())) {
               return -1;
             } else {
-              return 1;
+              // 从大到小排序 (Sort from large to small)
+              return -(nodeARm
+                  .getNodeResource()
+                  .getLeftResource()
+                  .compare(nodeBRm.getNodeResource().getLeftResource()));
             }
           }
         } catch (Throwable t) {

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/CPUResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/CPUResource.java
@@ -121,6 +121,12 @@ public class CPUResource extends Resource {
   }
 
   @Override
+  public int compare(Resource r) {
+    CPUResource cpuResource = toCPUResource(r);
+    return Integer.compare(this.getCores(), cpuResource.getCores());
+  }
+
+  @Override
   public String toJson() {
     return String.format(" \"cpu\":%s ", cores);
   }

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/DriverAndKubernetesResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/DriverAndKubernetesResource.java
@@ -200,6 +200,42 @@ public class DriverAndKubernetesResource extends Resource {
     return !notLess(r);
   }
 
+  @Override
+  public int compare(Resource resource) {
+    DriverAndKubernetesResource r = new DriverAndKubernetesResource(resource);
+    if (isModuleOperate(r)) {
+      return loadInstanceResource.compare(r.loadInstanceResource);
+    } else {
+      if (loadInstanceResource.getMemory() > r.loadInstanceResource.getMemory()) {
+        return 1;
+      } else if (loadInstanceResource.getMemory() < r.loadInstanceResource.getMemory()) {
+        return -1;
+      } else {
+        // If memory is equal, compare cores
+        if (loadInstanceResource.getCores() > r.loadInstanceResource.getCores()) {
+          return 1;
+        } else if (loadInstanceResource.getCores() < r.loadInstanceResource.getCores()) {
+          return -1;
+        } else {
+          // If cores are equal, compare instances
+          if (loadInstanceResource.getInstances() > r.loadInstanceResource.getInstances()) {
+            return 1;
+          } else if (loadInstanceResource.getInstances() < r.loadInstanceResource.getInstances()) {
+            return -1;
+          } else {
+            if (kubernetesResource.getMemory() > r.kubernetesResource.getMemory()) {
+              return 1;
+            } else if (kubernetesResource.getMemory() < r.kubernetesResource.getMemory()) {
+              return -1;
+            } else {
+              return Long.compare(kubernetesResource.getCores(), r.kubernetesResource.getCores());
+            }
+          }
+        }
+      }
+    }
+  }
+
   public String toJson() {
     String load = "null";
     String kubernetes = "null";

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/DriverAndYarnResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/DriverAndYarnResource.java
@@ -202,6 +202,43 @@ public class DriverAndYarnResource extends Resource {
     return !notLess(r);
   }
 
+  @Override
+  public int compare(Resource resource) {
+    DriverAndYarnResource r = new DriverAndYarnResource(resource);
+
+    if (isModuleOperate(r)) {
+      return loadInstanceResource.compare(r.loadInstanceResource);
+    } else {
+      if (loadInstanceResource.getMemory() > r.loadInstanceResource.getMemory()) {
+        return 1;
+      } else if (loadInstanceResource.getMemory() < r.loadInstanceResource.getMemory()) {
+        return -1;
+      } else {
+        // If memory is equal, compare cores
+        if (loadInstanceResource.getCores() > r.loadInstanceResource.getCores()) {
+          return 1;
+        } else if (loadInstanceResource.getCores() < r.loadInstanceResource.getCores()) {
+          return -1;
+        } else {
+          // If cores are equal, compare instances
+          if (loadInstanceResource.getInstances() > r.loadInstanceResource.getInstances()) {
+            return 1;
+          } else if (loadInstanceResource.getInstances() < r.loadInstanceResource.getInstances()) {
+            return -1;
+          } else {
+            if (yarnResource.getQueueMemory() > r.yarnResource.getQueueMemory()) {
+              return 1;
+            } else if (yarnResource.getQueueMemory() < r.yarnResource.getQueueMemory()) {
+              return -1;
+            } else {
+              return Integer.compare(yarnResource.getQueueCores(), r.yarnResource.getQueueCores());
+            }
+          }
+        }
+      }
+    }
+  }
+
   public String toJson() {
     String load = "null";
     String yarn = "null";

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/KubernetesResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/KubernetesResource.java
@@ -128,6 +128,19 @@ public class KubernetesResource extends Resource {
   }
 
   @Override
+  public int compare(Resource r) {
+    KubernetesResource temp = new KubernetesResource(r);
+    if (this.getMemory() > temp.getMemory()) {
+      return 1;
+    } else if (this.getMemory() < temp.getMemory()) {
+      return -1;
+    } else {
+      // If memory is equal, compare cores
+      return Long.compare(this.getCores(), temp.getCores());
+    }
+  }
+
+  @Override
   public String toJson() {
     return String.format(
         "{\"namespace\":\"%s\",\"memory\":\"%s\",\"cpu\":%d}",

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/LoadInstanceResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/LoadInstanceResource.java
@@ -139,6 +139,27 @@ public class LoadInstanceResource extends Resource {
   }
 
   @Override
+  public int compare(Resource r) {
+    LoadInstanceResource temp = new LoadInstanceResource(r);
+
+    if (this.getMemory() > temp.getMemory()) {
+      return 1;
+    } else if (this.getMemory() < temp.getMemory()) {
+      return -1;
+    } else {
+      // If memory is equal, compare cores
+      if (this.getCores() > temp.getCores()) {
+        return 1;
+      } else if (this.getCores() < temp.getCores()) {
+        return -1;
+      } else {
+        // If cores are equal, compare instances
+        return Integer.compare(this.getInstances(), temp.getInstances());
+      }
+    }
+  }
+
+  @Override
   public String toJson() {
     return String.format(
         "{\"instance\":%d,\"memory\":\"%s\",\"cpu\":%d}",

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/LoadResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/LoadResource.java
@@ -109,6 +109,20 @@ public class LoadResource extends Resource {
   }
 
   @Override
+  public int compare(Resource r) {
+    LoadResource temp = new LoadResource(r);
+
+    if (this.getMemory() > temp.getMemory()) {
+      return 1;
+    } else if (this.getMemory() < temp.getMemory()) {
+      return -1;
+    } else {
+      // If memory is equal, compare cores
+      return Integer.compare(this.getCores(), temp.getCores());
+    }
+  }
+
+  @Override
   public String toJson() {
     return String.format(
         "{\"memory\":%s,\"cpu\":%d}", ByteTimeUtils.bytesToString(this.memory), this.cores);

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/MemoryResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/MemoryResource.java
@@ -94,6 +94,12 @@ public class MemoryResource extends Resource {
   }
 
   @Override
+  public int compare(Resource resource) {
+    MemoryResource r = toMemoryResource(resource);
+    return Long.compare(this.getMemory(), r.getMemory());
+  }
+
+  @Override
   public boolean caseMore(Resource r) {
     return moreThan(r);
   }

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/Resource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/Resource.java
@@ -122,6 +122,8 @@ public abstract class Resource {
 
   public abstract boolean less(Resource r);
 
+  public abstract int compare(Resource r);
+
   public Resource add(Resource r, float rate) {
     return this.add(r.multiplied(rate));
   }

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/SpecialResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/SpecialResource.java
@@ -349,6 +349,17 @@ public class SpecialResource extends Resource {
   }
 
   @Override
+  public int compare(Resource r) {
+    if (this.moreThan(r)) {
+      return 1;
+    } else if (this.less(r)) {
+      return -1;
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
   public String toJson() {
     return String.format("Special:%s", resources);
   }

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/YarnResource.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/resource/YarnResource.java
@@ -161,6 +161,18 @@ public class YarnResource extends Resource {
   }
 
   @Override
+  public int compare(Resource resource) {
+    YarnResource r = toYarnResource(resource);
+    if (this.getQueueMemory() > r.getQueueMemory()) {
+      return 1;
+    } else if (this.getQueueMemory() < r.getQueueMemory()) {
+      return -1;
+    } else {
+      return Integer.compare(this.getQueueCores(), r.getQueueCores());
+    }
+  }
+
+  @Override
   public String toJson() {
     return String.format(
         "{\"queueName\":\"%s\",\"queueMemory\":\"%s\",\"queueCpu\":%d, \"instance\":%d}",


### PR DESCRIPTION
### What is the purpose of the change

Fix the bug that the sortByResource method in ResourceNodeSelectRule violates the general contract of comparators.

### Related issues/PRs

Related issues: #4911


### Brief change log

- Added and implemented a compare method for the Resource abstract class and its subclasses.;
- Modified the Java class ResourceNodeSelectRule to ensure that sortByResource uses the correct sorting method.


### Note
- For LoadInstanceResource, memory is compared first. If the memory is the same, the number of CPU cores is compared. When the number of CPU cores is the same, the number of instances that have been launched will be compared. Other subcategories also adopted similar comparison rules.


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [x] **If this is a code change**: I have written unit tests to fully verify the new behavior.



