### PR TITLE
Update SqlConnection.java

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/oracle/SqlConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/oracle/SqlConnection.java
@@ -182,7 +182,7 @@ public class SqlConnection extends AbstractSqlConnection {
               SQL_CONNECT_SERVICE_URL.getValue(),
               connectMessage.host,
               connectMessage.port,
-              database);
+              serviceName);
     }
 
     if (MapUtils.isNotEmpty(connectMessage.extraParams)) {


### PR DESCRIPTION

### What is the purpose of the change

When use service_name to connect to oracle, should pass in serviceName instead of database

### Related issues/PRs

### Brief change log
Use serviceName instead of database
### Checklist

- [x] I have read the [[Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests)](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [[Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe)](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.

