### PR TITLE
Fix flaky test in ExceptionManagerTest.java

### DIFF
--- a/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/exception/ExceptionManagerTest.java
+++ b/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/exception/ExceptionManagerTest.java
@@ -21,6 +21,7 @@ import org.apache.linkis.common.errorcode.CommonErrorConstants;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,7 @@ class ExceptionManagerTest {
                 + "null");
     assertEquals(errorException.getClass(), ExceptionManager.generateException(null).getClass());
     assertEquals(errorException.toString(), ExceptionManager.generateException(null).toString());
-    Map<String, Object> map = new HashMap<>();
+    Map<String, Object> map = new TreeMap<>();
     map.put("level", null);
     map.put("errCode", 1);
     map.put("desc", "test");


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

Fix the flaky test detected under the `ExceptionManagerTest.java` under `links-commons` module.

### Related issues/PRs

Related issues: #5004 
Related pr: N/A


### Brief change log

There was a map added at the end of the errorException message. Since the HashMap is an unordered data structure, the key-value pair may not stay in the same order every time. That's why sometimes the expected value does not match the actual value. I slightly modified the code to change the HashMap to TreeMap to solve this issue.

The failed log looks like:
```
[ERROR] Failures: 
[ERROR]   ExceptionManagerTest.testGenerateException:55 expected: <LinkisException{errCode=10000, desc='The map
cannot be parsed normally, the map is empty or the LEVEL value is missing:(map不能被正常的解析，map为空或者缺少LEVEL值: ){desc=test, ip=null, errCode=1, serviceKind=null, port=0, level=null}', ip='null', port=0, serviceKind='null'}> but was:
<LinkisException{errCode=10000, desc='The map cannot be parsed normally, the map is empty or the LEVEL value is
missing:(map不能被正常的解析，map为空或者缺少LEVEL值: ){port=0, desc=test, level=null, ip=null, errCode=1,
serviceKind=null}', ip='null', port=0, serviceKind='null'}>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
 After the fix, the failure no longer exists:
```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.053 s - in
org.apache.linkis.common.exception.ExceptionManagerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```
 


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
