### PR TITLE
When reading data using JDBC, add support for the smallint and tinyint

### DIFF
--- a/linkis-computation-governance/linkis-jdbc-driver/src/main/scala/org/apache/linkis/ujes/jdbc/UJESSQLResultSet.scala
+++ b/linkis-computation-governance/linkis-jdbc-driver/src/main/scala/org/apache/linkis/ujes/jdbc/UJESSQLResultSet.scala
@@ -244,6 +244,8 @@ class UJESSQLResultSet(
         case null => throw new LinkisSQLException(LinkisSQLErrorCode.METADATA_EMPTY)
         case "char" | "varchar" | "nvarchar" | "string" => value
         case "short" => value.toShort
+        case "smallint" => value.toShort
+        case "tinyint" => value.toShort
         case "int" => value.toInt
         case "long" => value.toLong
         case "float" => value.toFloat


### PR DESCRIPTION
### What is the purpose of the change

When using a JDBC connection to read results from linkis, add support for the smallint and tinyint data types

### Related issues/PRs

Related issues: #5050 


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [x] **If this is a code change**: I have written unit tests to fully verify the new behavior.