### PR TITLE
fix cancelled task still executed

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/persistence/QueryPersistenceManager.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/persistence/QueryPersistenceManager.java
@@ -190,7 +190,7 @@ public class QueryPersistenceManager extends PersistenceManager {
       createPersistenceEngine().updateIfNeeded(jobRequest);
     } catch (ErrorException e) {
       entranceContext.getOrCreateLogManager().onLogUpdate(job, e.getMessage());
-      logger.error("update job status failed, reason: ", e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
### What is the purpose of the change
Fix the bug where cancelled tasks continue to execute.

### Related issues/PRs

Related issues:  #5073 


### Brief change log

- 修改QueryPersistenceManager.updateJobStatus，如果状态更新失败则主动抛出异常。[Modify the QueryPersistenceManager.updateJobStatus method so that if the status update fails, it actively throws an exception.]


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [x] **If this is a code change**: I have written unit tests to fully verify the new behavior.
