### PR TITLE
Add a containerized mode to the ECM service

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -166,15 +166,15 @@ jobs:
           # Show port-forward list
           bash ./linkis-dist/helm/scripts/remote-proxy.sh list
           # Check if the web service is available
-          curl http://127.0.0.1:8088/indexhtml
+          curl http://127.0.0.1:8088/
 
           # Execute test by linkis-cli
           POD_NAME=`kubectl get pods -n linkis -l app.kubernetes.io/instance=linkis-demo-mg-gateway -o jsonpath='{.items[0].metadata.name}'`
           kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
-          sh /opt/linkis/bin/linkis-cli -engineType shell-1 -codeType shell -code \"pwd\" ";
-
-          kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
-          sh /opt/linkis/bin/linkis-cli -engineType python-python2 -codeType python -code   'print(\"hello\")' "
+          sh /opt/linkis/bin/linkis-cli --async true -engineType shell-1 -codeType shell -code \"pwd\" ";
+          sleep 300
+          #kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
+          #sh /opt/linkis/bin/linkis-cli -engineType python-python2 -codeType python -code   'print(\"hello\")' "
 
           #todo
           #kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -171,10 +171,10 @@ jobs:
           # Execute test by linkis-cli
           POD_NAME=`kubectl get pods -n linkis -l app.kubernetes.io/instance=linkis-demo-mg-gateway -o jsonpath='{.items[0].metadata.name}'`
           kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
-          sh /opt/linkis/bin/linkis-cli --async true -engineType shell-1 -codeType shell -code \"pwd\" ";
-          sleep 300
-          #kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
-          #sh /opt/linkis/bin/linkis-cli -engineType python-python2 -codeType python -code   'print(\"hello\")' "
+          sh /opt/linkis/bin/linkis-cli -engineType shell-1 -codeType shell -code \"pwd\" ";
+
+          kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
+          sh /opt/linkis/bin/linkis-cli -engineType python-python2 -codeType python -code   'print(\"hello\")' "
 
           #todo
           #kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
@@ -182,6 +182,4 @@ jobs:
 
           #kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
           #sh /opt/linkis/bin/linkis-cli -engineType spark-3.2.1 -codeType sql -code   'show databases' "
-          POD_NAME=`kubectl get pods -n linkis -l app.kubernetes.io/instance=linkis-demo-cg-linkismanager -o jsonpath='{.items[0].metadata.name}'`
-          kubectl logs -n linkis  ${POD_NAME} -f --tail=10000
         shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -182,5 +182,6 @@ jobs:
 
           #kubectl exec -it -n linkis  ${POD_NAME} -- bash -c " \
           #sh /opt/linkis/bin/linkis-cli -engineType spark-3.2.1 -codeType sql -code   'show databases' "
-
+          POD_NAME=`kubectl get pods -n linkis -l app.kubernetes.io/instance=linkis-demo-cg-linkismanager -o jsonpath='{.items[0].metadata.name}'`
+          kubectl logs -n linkis  ${POD_NAME} -f --tail=10000
         shell: bash

--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/ServiceInstance.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/ServiceInstance.scala
@@ -21,10 +21,18 @@ class ServiceInstance {
   private var applicationName: String = _
   private var instance: String = _
   private var registryTimestamp: Long = _
+  private var mappingPorts: String = _
+  private var mappingHost: String = _
   def setApplicationName(applicationName: String): Unit = this.applicationName = applicationName
   def getApplicationName: String = applicationName
   def setInstance(instance: String): Unit = this.instance = instance
   def getInstance: String = instance
+
+  def setMappingPorts(mappingPorts: String): Unit = this.mappingPorts = mappingPorts
+  def getMappingPorts: String = mappingPorts
+
+  def setMappingHost(mappingHost: String): Unit = this.mappingHost = mappingHost
+  def getMappingHost: String = mappingHost
 
   def setRegistryTimestamp(registryTimestamp: Long): Unit = this.registryTimestamp =
     registryTimestamp
@@ -59,6 +67,18 @@ object ServiceInstance {
     val serviceInstance = new ServiceInstance
     serviceInstance.setApplicationName(applicationName)
     serviceInstance.setInstance(instance)
+    serviceInstance
+  }
+
+  def apply(
+      applicationName: String,
+      instance: String,
+      mappingPorts: String,
+      mappingHost: String
+  ): ServiceInstance = {
+    val serviceInstance = apply(applicationName, instance)
+    serviceInstance.setMappingPorts(mappingPorts)
+    serviceInstance.setMappingHost(mappingHost)
     serviceInstance
   }
 

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/java/org/apache/linkis/ecm/core/containerization/enums/MappingPortStrategyName.java
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/java/org/apache/linkis/ecm/core/containerization/enums/MappingPortStrategyName.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.ecm.core.containerization.enums;
+
+public enum MappingPortStrategyName {
+  STATIC("static");
+  private String name;
+
+  MappingPortStrategyName(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public static MappingPortStrategyName toEnum(String name) {
+    return MappingPortStrategyName.valueOf(name.toUpperCase());
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/java/org/apache/linkis/ecm/core/containerization/strategy/MappingPortContext.java
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/java/org/apache/linkis/ecm/core/containerization/strategy/MappingPortContext.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.ecm.core.containerization.strategy;
+
+import org.apache.linkis.ecm.core.containerization.enums.MappingPortStrategyName;
+
+public class MappingPortContext {
+
+  public static MappingPortStrategy getInstance(MappingPortStrategyName strategyName) {
+    switch (strategyName) {
+      case STATIC:
+        return new StaticMappingPortStrategy();
+      default:
+        return new StaticMappingPortStrategy();
+    }
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/java/org/apache/linkis/ecm/core/containerization/strategy/MappingPortStrategy.java
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/java/org/apache/linkis/ecm/core/containerization/strategy/MappingPortStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.ecm.core.containerization.strategy;
+
+import java.io.IOException;
+
+public interface MappingPortStrategy {
+  int availablePort() throws IOException;
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/java/org/apache/linkis/ecm/core/containerization/strategy/StaticMappingPortStrategy.java
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/java/org/apache/linkis/ecm/core/containerization/strategy/StaticMappingPortStrategy.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.ecm.core.containerization.strategy;
+
+import org.apache.linkis.ecm.core.conf.ContainerizationConf;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StaticMappingPortStrategy implements MappingPortStrategy {
+
+  private static final AtomicInteger currentIndex = new AtomicInteger(0);
+
+  @Override
+  public int availablePort() throws IOException {
+    return getNewPort(10);
+  }
+
+  public int getNewPort(int retryNum) throws IOException {
+    int[] portRange = getPortRange();
+    if (retryNum == 0) {
+      throw new IOException(
+          "No available port in the portRange: "
+              + ContainerizationConf.ENGINE_CONN_CONTAINERIZATION_MAPPING_STATTIC_PORT_RANGE()
+                  .getValue());
+    }
+    moveIndex();
+    int minPort = portRange[0];
+    int newPort = minPort + currentIndex.get() - 1;
+    ServerSocket socket = null;
+    try {
+      socket = new ServerSocket(newPort);
+    } catch (Exception e) {
+      return getNewPort(--retryNum);
+    } finally {
+      IOUtils.close(socket);
+    }
+    return newPort;
+  }
+
+  private synchronized void moveIndex() {
+    int poolSize = getPoolSize();
+    currentIndex.set(currentIndex.get() % poolSize + 1);
+  }
+
+  private int[] getPortRange() {
+    String portRange =
+        ContainerizationConf.ENGINE_CONN_CONTAINERIZATION_MAPPING_STATTIC_PORT_RANGE().getValue();
+
+    return Arrays.stream(portRange.split("-")).mapToInt(Integer::parseInt).toArray();
+  }
+
+  private int getPoolSize() {
+    int[] portRange = getPortRange();
+    int minPort = portRange[0];
+    int maxPort = portRange[1];
+
+    return maxPort - minPort + 1;
+  }
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/org/apache/linkis/ecm/core/conf/ContainerizationConf.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-core/src/main/scala/org/apache/linkis/ecm/core/conf/ContainerizationConf.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.ecm.core.conf
+
+import org.apache.linkis.common.conf.CommonVars
+
+object ContainerizationConf {
+
+  val ENGINE_CONN_CONTAINERIZATION_MAPPING_STATTIC_PORT_RANGE =
+    CommonVars("linkis.engine.containerization.static.port.range", "1-65535")
+
+  val ENGINE_CONN_CONTAINERIZATION_ENABLE =
+    CommonVars("linkis.engine.containerization.enable", false).getValue
+
+  val ENGINE_CONN_CONTAINERIZATION_MAPPING_HOST =
+    CommonVars("linkis.engine.containerization.mapping.host", "")
+
+  val ENGINE_CONN_CONTAINERIZATION_MAPPING_PORTS =
+    CommonVars("linkis.engine.containerization.mapping.ports", "")
+
+  val ENGINE_CONN_CONTAINERIZATION_MAPPING_STRATEGY =
+    CommonVars("linkis.engine.containerization.mapping.strategy", "static")
+
+  // 引擎类型-需要开启的端口数量
+  // Engine Type - Number of Ports Required to Be Opened
+  val ENGINE_CONN_CONTAINERIZATION_ENGINE_LIST =
+    CommonVars("linkis.engine.containerization.engine.list", "spark-2,")
+
+}

--- a/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/org/apache/linkis/ecm/server/service/impl/AbstractEngineConnLaunchService.scala
+++ b/linkis-computation-governance/linkis-engineconn-manager/linkis-engineconn-manager-server/src/main/scala/org/apache/linkis/ecm/server/service/impl/AbstractEngineConnLaunchService.scala
@@ -92,7 +92,9 @@ abstract class AbstractEngineConnLaunchService extends EngineConnLaunchService w
         case pro: ProcessEngineConnLaunch =>
           val serviceInstance = ServiceInstance(
             GovernanceCommonConf.ENGINE_CONN_SPRING_NAME.getValue,
-            ECMUtils.getInstanceByPort(pro.getEngineConnPort)
+            ECMUtils.getInstanceByPort(pro.getEngineConnPort),
+            pro.getMappingPorts,
+            pro.getMappingHost
           )
           conn.setServiceInstance(serviceInstance)
         case _ =>

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/vo/AMEngineNodeVo.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/vo/AMEngineNodeVo.java
@@ -80,6 +80,10 @@ public class AMEngineNodeVo {
 
   private String engineType;
 
+  private String mappingPorts;
+
+  private String mappingHost;
+
   public String getEmInstance() {
     return emInstance;
   }
@@ -287,5 +291,21 @@ public class AMEngineNodeVo {
 
   public void setEngineType(String engineType) {
     this.engineType = engineType;
+  }
+
+  public String getMappingPorts() {
+    return mappingPorts;
+  }
+
+  public void setMappingPorts(String mappingPorts) {
+    this.mappingPorts = mappingPorts;
+  }
+
+  public String getMappingHost() {
+    return mappingHost;
+  }
+
+  public void setMappingHost(String mappingHost) {
+    this.mappingHost = mappingHost;
   }
 }

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/utils/AMUtils.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/utils/AMUtils.scala
@@ -167,6 +167,8 @@ object AMUtils {
         AMEngineNodeVo.setLabels(node.getLabels)
         AMEngineNodeVo.setApplicationName(node.getServiceInstance.getApplicationName)
         AMEngineNodeVo.setInstance(node.getServiceInstance.getInstance)
+        AMEngineNodeVo.setMappingHost(node.getServiceInstance.getMappingHost)
+        AMEngineNodeVo.setMappingPorts(node.getServiceInstance.getMappingPorts)
         if (null != node.getEMNode) {
           AMEngineNodeVo.setEmInstance(node.getEMNode.getServiceInstance.getInstance)
         }

--- a/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/persistence/PersistenceNode.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-common/src/main/java/org/apache/linkis/manager/common/entity/persistence/PersistenceNode.java
@@ -36,6 +36,9 @@ public class PersistenceNode {
   private String updator;
   private String creator;
 
+  private String mappingPorts;
+  private String mappingHost;
+
   public String getMark() {
     return mark;
   }
@@ -122,5 +125,21 @@ public class PersistenceNode {
 
   public void setCreator(String creator) {
     this.creator = creator;
+  }
+
+  public String getMappingPorts() {
+    return mappingPorts;
+  }
+
+  public void setMappingPorts(String mappingPorts) {
+    this.mappingPorts = mappingPorts;
+  }
+
+  public String getMappingHost() {
+    return mappingHost;
+  }
+
+  public void setMappingHost(String mappingHost) {
+    this.mappingHost = mappingHost;
   }
 }

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/persistence/impl/DefaultNodeManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/persistence/impl/DefaultNodeManagerPersistence.java
@@ -109,6 +109,10 @@ public class DefaultNodeManagerPersistence implements NodeManagerPersistence {
         node.getOwner()); // The creator is not given when inserting records in rm, so you need to
     // set this value(rm中插入记录的时候并未给出creator，所以需要set这个值)
     persistenceNode.setUpdator(node.getOwner());
+    String mappingPorts = node.getServiceInstance().getMappingPorts();
+    persistenceNode.setMappingPorts(mappingPorts);
+    String mappingHost = node.getServiceInstance().getMappingHost();
+    persistenceNode.setMappingHost(mappingHost);
     try {
       nodeManagerMapper.updateNodeInstance(serviceInstance.getInstance(), persistenceNode);
       nodeManagerMapper.updateNodeRelation(
@@ -277,6 +281,8 @@ public class DefaultNodeManagerPersistence implements NodeManagerPersistence {
       ServiceInstance emServiceInstance = new ServiceInstance();
       emServiceInstance.setApplicationName(emName);
       emServiceInstance.setInstance(emInstance);
+      emServiceInstance.setMappingPorts(String.valueOf(emNode.getMappingPorts()));
+      emServiceInstance.setMappingHost(String.valueOf(emNode.getMappingHost()));
       AMEMNode amemNode = new AMEMNode();
       amemNode.setMark(emNode.getMark());
       amemNode.setOwner(emNode.getOwner());
@@ -331,6 +337,8 @@ public class DefaultNodeManagerPersistence implements NodeManagerPersistence {
       ServiceInstance engineServiceInstance = new ServiceInstance();
       engineServiceInstance.setInstance(engineNode.getInstance());
       engineServiceInstance.setApplicationName(engineNode.getName());
+      engineServiceInstance.setMappingPorts(String.valueOf(engineNode.getMappingPorts()));
+      engineServiceInstance.setMappingHost(String.valueOf(engineNode.getMappingHost()));
       amEngineNode.setServiceInstance(engineServiceInstance);
       amEngineNode.setOwner(engineNode.getOwner());
       amEngineNode.setMark(engineNode.getMark());

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/resources/mapper/common/NodeManagerMapper.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/resources/mapper/common/NodeManagerMapper.xml
@@ -66,6 +66,12 @@
             <if test="persistenceNode.identifier != null">
                 identifier = #{persistenceNode.identifier},
             </if>
+            <if test="persistenceNode.mappingPorts != null">
+                mapping_ports = #{persistenceNode.mappingPorts},
+            </if>
+            <if test="persistenceNode.mappingHost != null">
+                mapping_host = #{persistenceNode.mappingHost},
+            </if>
         </set>
         WHERE instance = #{instance}
     </update>

--- a/linkis-dist/helm/charts/linkis/templates/configmap-init-sql.yaml
+++ b/linkis-dist/helm/charts/linkis/templates/configmap-init-sql.yaml
@@ -723,6 +723,7 @@ data:
     `owner` varchar(32) COLLATE utf8_bin DEFAULT NULL,
     `mark` varchar(32) COLLATE utf8_bin DEFAULT NULL,
     `identifier` varchar(32) COLLATE utf8_bin DEFAULT NULL,
+    `ticketId` varchar(255) COLLATE utf8_bin DEFAULT NULL,
     `mapping_host` varchar(128) COLLATE utf8_bin DEFAULT NULL,
     `mapping_ports` varchar(128) COLLATE utf8_bin DEFAULT NULL,
     `update_time` datetime DEFAULT CURRENT_TIMESTAMP,

--- a/linkis-dist/helm/charts/linkis/templates/configmap-init-sql.yaml
+++ b/linkis-dist/helm/charts/linkis/templates/configmap-init-sql.yaml
@@ -723,6 +723,8 @@ data:
     `owner` varchar(32) COLLATE utf8_bin DEFAULT NULL,
     `mark` varchar(32) COLLATE utf8_bin DEFAULT NULL,
     `identifier` varchar(32) COLLATE utf8_bin DEFAULT NULL,
+    `mapping_host` varchar(128) COLLATE utf8_bin DEFAULT NULL,
+    `mapping_ports` varchar(128) COLLATE utf8_bin DEFAULT NULL,
     `update_time` datetime DEFAULT CURRENT_TIMESTAMP,
     `create_time` datetime DEFAULT CURRENT_TIMESTAMP,
     `updator` varchar(32) COLLATE utf8_bin DEFAULT NULL,

--- a/linkis-dist/helm/charts/linkis/templates/configmap-init-sql.yaml
+++ b/linkis-dist/helm/charts/linkis/templates/configmap-init-sql.yaml
@@ -193,6 +193,7 @@ data:
     `engine_type` varchar(32) DEFAULT NULL COMMENT 'Engine type',
     `execution_code` text DEFAULT NULL COMMENT 'Job origin code or code path',
     `result_location` varchar(500) DEFAULT NULL COMMENT 'File path of the resultsets',
+    `observe_info` varchar(500) DEFAULT NULL COMMENT 'The notification information configuration of this job',
     PRIMARY KEY (`id`),
     KEY `created_time` (`created_time`),
     KEY `submit_user` (`submit_user`)

--- a/linkis-dist/package/db/linkis_ddl.sql
+++ b/linkis-dist/package/db/linkis_ddl.sql
@@ -751,6 +751,8 @@ CREATE TABLE `linkis_cg_manager_service_instance` (
   `mark` varchar(32) COLLATE utf8_bin DEFAULT NULL,
   `identifier` varchar(32) COLLATE utf8_bin DEFAULT NULL,
   `ticketId` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `mapping_host` varchar(128) COLLATE utf8_bin DEFAULT NULL,
+  `mapping_ports` varchar(128) COLLATE utf8_bin DEFAULT NULL,
   `update_time` datetime DEFAULT CURRENT_TIMESTAMP,
   `create_time` datetime DEFAULT CURRENT_TIMESTAMP,
   `updator` varchar(32) COLLATE utf8_bin DEFAULT NULL,

--- a/linkis-dist/package/db/linkis_ddl_pg.sql
+++ b/linkis-dist/package/db/linkis_ddl_pg.sql
@@ -804,6 +804,8 @@ CREATE TABLE linkis_cg_manager_service_instance (
 	mark varchar(32) NULL,
 	identifier varchar(32) NULL,
 	ticketId varchar(255) NULL DEFAULT NULL,
+    mapping_host varchar(128) NULL DEFAULT NULL,
+    mapping_ports varchar(128) NULL DEFAULT NULL,
 	update_time timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP,
 	create_time timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP,
 	updator varchar(32) NULL,

--- a/linkis-dist/package/db/upgrade/1.7.0_schema/mysql/linkis_ddl.sql
+++ b/linkis-dist/package/db/upgrade/1.7.0_schema/mysql/linkis_ddl.sql
@@ -95,6 +95,10 @@ CREATE TABLE `linkis_ps_python_module_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 
+ALTER TABLE `linkis_cg_manager_service_instance` ADD COLUMN mapping_ports varchar(128);
+ALTER TABLE `linkis_cg_manager_service_instance` ADD COLUMN mapping_host varchar(128);
+
+
 
 
 

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/context/SparkConfig.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/context/SparkConfig.java
@@ -24,548 +24,548 @@ import java.util.Map;
 
 public class SparkConfig {
 
-    private String javaHome; // ("")
-    private String sparkHome; // ("")
-    private String master = "yarn"; // ("yarn")
-
-    private String k8sConfigFile;
-
-    private String k8sServiceAccount;
-
-    private String k8sMasterUrl;
-
-    private String k8sUsername;
-
-    private String k8sPassword;
-
-    private String k8sImage;
-
-    private String k8sImagePullPolicy;
-
-    private String k8sLanguageType;
-
-    private String k8sRestartPolicy;
-
-    private String k8sSparkVersion;
-
-    private String k8sNamespace;
-    private String k8sFileUploadPath;
-
-    private String k8sDriverRequestCores;
-    private String k8sExecutorRequestCores;
-    private String k8sSparkUIPort;
-    private String deployMode = "client"; // ("client") // todo cluster
-    private String appResource; // ("")
-    private String appName; // ("")
-    private String jars; // ("--jars", "")
-    private String packages; // ("--packages", "")
-    private String excludePackages; // ("--exclude-packages", "")
-    private String repositories; // ("--repositories", "")
-    private String files; // ("--files", "")
-    private String archives; // ("--archives", "")
-    private Map<String, String> conf = new HashMap<>(); // ("", "")
-    private String propertiesFile; // ("")
-    private String driverMemory; // ("--driver-memory", "")
-    private String driverJavaOptions; // ("--driver-java-options", "")
-    private String driverLibraryPath; // ("--driver-library-path", "")
-    private String driverClassPath; // ("--driver-class-path", "")
-    private String executorMemory; // ("--executor-memory", "")
-    private String proxyUser; // ("--proxy-user", "")
-    private boolean verbose = false; // (false)
-    private Integer driverCores; // ("--driver-cores", "") // Cluster deploy mode only
-    private String totalExecutorCores; // ("--total-executor-cores", "")
-    private Integer executorCores; // ("--executor-cores", "")
-    private Integer numExecutors; // ("--num-executors", "")
-    private String principal; // ("--principal", "")
-    private String keytab; // ("--keytab", "")
-    private String queue; // ("--queue", "")
-    private String pyFiles; // ("--py-files", "")
-
-    public String getK8sFileUploadPath() {
-        return k8sFileUploadPath;
-    }
-
-    public void setK8sFileUploadPath(String k8sFileUploadPath) {
-        this.k8sFileUploadPath = k8sFileUploadPath;
-    }
-
-    public String getK8sImagePullPolicy() {
-        return k8sImagePullPolicy;
-    }
-
-    public void setK8sImagePullPolicy(String k8sImagePullPolicy) {
-        this.k8sImagePullPolicy = k8sImagePullPolicy;
-    }
-
-    public String getK8sLanguageType() {
-        return k8sLanguageType;
-    }
-
-    public void setK8sLanguageType(String k8sLanguageType) {
-        this.k8sLanguageType = k8sLanguageType;
-    }
-
-    public String getK8sRestartPolicy() {
-        return k8sRestartPolicy;
-    }
-
-    public void setK8sRestartPolicy(String k8sRestartPolicy) {
-        this.k8sRestartPolicy = k8sRestartPolicy;
-    }
-
-    public String getK8sSparkVersion() {
-        return k8sSparkVersion;
-    }
-
-    public void setK8sSparkVersion(String k8sSparkVersion) {
-        this.k8sSparkVersion = k8sSparkVersion;
-    }
-
-    public String getK8sNamespace() {
-        return k8sNamespace;
-    }
-
-    public void setK8sNamespace(String k8sNamespace) {
-        this.k8sNamespace = k8sNamespace;
-    }
-
-    public String getK8sMasterUrl() {
-        return k8sMasterUrl;
-    }
-
-    public String getK8sConfigFile() {
-        return k8sConfigFile;
-    }
-
-    public void setK8sConfigFile(String k8sConfigFile) {
-        if (StringUtils.isNotBlank(k8sConfigFile) && k8sConfigFile.startsWith("~")) {
-            String user = System.getProperty("user.home");
-            k8sConfigFile = k8sConfigFile.replaceFirst("~", user);
-        }
-        this.k8sConfigFile = k8sConfigFile;
-    }
-
-    public String getK8sServiceAccount() {
-        return k8sServiceAccount;
-    }
-
-    public void setK8sServiceAccount(String k8sServiceAccount) {
-        this.k8sServiceAccount = k8sServiceAccount;
-    }
-
-    public void setK8sMasterUrl(String k8sMasterUrl) {
-        this.k8sMasterUrl = k8sMasterUrl;
-    }
-
-    public String getK8sUsername() {
-        return k8sUsername;
-    }
-
-    public void setK8sUsername(String k8sUsername) {
-        this.k8sUsername = k8sUsername;
-    }
-
-    public String getK8sPassword() {
-        return k8sPassword;
-    }
-
-    public void setK8sPassword(String k8sPassword) {
-        this.k8sPassword = k8sPassword;
-    }
-
-    public String getK8sImage() {
-        return k8sImage;
-    }
-
-    public void setK8sImage(String k8sImage) {
-        this.k8sImage = k8sImage;
-    }
-
-    public String getK8sDriverRequestCores() {
-        return k8sDriverRequestCores;
-    }
-
-    public void setK8sDriverRequestCores(String k8sDriverRequestCores) {
-        this.k8sDriverRequestCores = k8sDriverRequestCores;
-    }
-
-    public String getK8sExecutorRequestCores() {
-        return k8sExecutorRequestCores;
-    }
-
-    public void setK8sExecutorRequestCores(String k8sExecutorRequestCores) {
-        this.k8sExecutorRequestCores = k8sExecutorRequestCores;
-    }
-
-    public String getK8sSparkUIPort() {
-        return k8sSparkUIPort;
-    }
-
-    public void setK8sSparkUIPort(String k8sSparkUIPort) {
-        this.k8sSparkUIPort = k8sSparkUIPort;
-    }
-
-    public String getJavaHome() {
-        return javaHome;
-    }
+  private String javaHome; // ("")
+  private String sparkHome; // ("")
+  private String master = "yarn"; // ("yarn")
+
+  private String k8sConfigFile;
+
+  private String k8sServiceAccount;
+
+  private String k8sMasterUrl;
+
+  private String k8sUsername;
+
+  private String k8sPassword;
+
+  private String k8sImage;
+
+  private String k8sImagePullPolicy;
+
+  private String k8sLanguageType;
+
+  private String k8sRestartPolicy;
+
+  private String k8sSparkVersion;
+
+  private String k8sNamespace;
+  private String k8sFileUploadPath;
+
+  private String k8sDriverRequestCores;
+  private String k8sExecutorRequestCores;
+  private String k8sSparkUIPort;
+  private String deployMode = "client"; // ("client") // todo cluster
+  private String appResource; // ("")
+  private String appName; // ("")
+  private String jars; // ("--jars", "")
+  private String packages; // ("--packages", "")
+  private String excludePackages; // ("--exclude-packages", "")
+  private String repositories; // ("--repositories", "")
+  private String files; // ("--files", "")
+  private String archives; // ("--archives", "")
+  private Map<String, String> conf = new HashMap<>(); // ("", "")
+  private String propertiesFile; // ("")
+  private String driverMemory; // ("--driver-memory", "")
+  private String driverJavaOptions; // ("--driver-java-options", "")
+  private String driverLibraryPath; // ("--driver-library-path", "")
+  private String driverClassPath; // ("--driver-class-path", "")
+  private String executorMemory; // ("--executor-memory", "")
+  private String proxyUser; // ("--proxy-user", "")
+  private boolean verbose = false; // (false)
+  private Integer driverCores; // ("--driver-cores", "") // Cluster deploy mode only
+  private String totalExecutorCores; // ("--total-executor-cores", "")
+  private Integer executorCores; // ("--executor-cores", "")
+  private Integer numExecutors; // ("--num-executors", "")
+  private String principal; // ("--principal", "")
+  private String keytab; // ("--keytab", "")
+  private String queue; // ("--queue", "")
+  private String pyFiles; // ("--py-files", "")
+
+  public String getK8sFileUploadPath() {
+    return k8sFileUploadPath;
+  }
+
+  public void setK8sFileUploadPath(String k8sFileUploadPath) {
+    this.k8sFileUploadPath = k8sFileUploadPath;
+  }
+
+  public String getK8sImagePullPolicy() {
+    return k8sImagePullPolicy;
+  }
+
+  public void setK8sImagePullPolicy(String k8sImagePullPolicy) {
+    this.k8sImagePullPolicy = k8sImagePullPolicy;
+  }
+
+  public String getK8sLanguageType() {
+    return k8sLanguageType;
+  }
+
+  public void setK8sLanguageType(String k8sLanguageType) {
+    this.k8sLanguageType = k8sLanguageType;
+  }
+
+  public String getK8sRestartPolicy() {
+    return k8sRestartPolicy;
+  }
+
+  public void setK8sRestartPolicy(String k8sRestartPolicy) {
+    this.k8sRestartPolicy = k8sRestartPolicy;
+  }
+
+  public String getK8sSparkVersion() {
+    return k8sSparkVersion;
+  }
+
+  public void setK8sSparkVersion(String k8sSparkVersion) {
+    this.k8sSparkVersion = k8sSparkVersion;
+  }
+
+  public String getK8sNamespace() {
+    return k8sNamespace;
+  }
+
+  public void setK8sNamespace(String k8sNamespace) {
+    this.k8sNamespace = k8sNamespace;
+  }
 
-    public void setJavaHome(String javaHome) {
-        this.javaHome = javaHome;
-    }
-
-    public String getSparkHome() {
-        return sparkHome;
-    }
-
-    public void setSparkHome(String sparkHome) {
-        this.sparkHome = sparkHome;
-    }
-
-    public String getMaster() {
-        return master;
-    }
+  public String getK8sMasterUrl() {
+    return k8sMasterUrl;
+  }
 
-    public void setMaster(String master) {
-        this.master = master;
-    }
-
-    public String getDeployMode() {
-        return deployMode;
-    }
-
-    public void setDeployMode(String deployMode) {
-        this.deployMode = deployMode;
-    }
+  public String getK8sConfigFile() {
+    return k8sConfigFile;
+  }
 
-    public String getAppResource() {
-        return appResource;
+  public void setK8sConfigFile(String k8sConfigFile) {
+    if (StringUtils.isNotBlank(k8sConfigFile) && k8sConfigFile.startsWith("~")) {
+      String user = System.getProperty("user.home");
+      k8sConfigFile = k8sConfigFile.replaceFirst("~", user);
     }
+    this.k8sConfigFile = k8sConfigFile;
+  }
 
-    public void setAppResource(String appResource) {
-        this.appResource = appResource;
-    }
+  public String getK8sServiceAccount() {
+    return k8sServiceAccount;
+  }
 
-    public String getAppName() {
-        return appName;
-    }
+  public void setK8sServiceAccount(String k8sServiceAccount) {
+    this.k8sServiceAccount = k8sServiceAccount;
+  }
 
-    public void setAppName(String appName) {
-        this.appName = appName;
-    }
+  public void setK8sMasterUrl(String k8sMasterUrl) {
+    this.k8sMasterUrl = k8sMasterUrl;
+  }
 
-    public String getJars() {
-        return jars;
-    }
+  public String getK8sUsername() {
+    return k8sUsername;
+  }
 
-    public void setJars(String jars) {
-        this.jars = jars;
-    }
+  public void setK8sUsername(String k8sUsername) {
+    this.k8sUsername = k8sUsername;
+  }
 
-    public String getPackages() {
-        return packages;
-    }
+  public String getK8sPassword() {
+    return k8sPassword;
+  }
 
-    public void setPackages(String packages) {
-        this.packages = packages;
-    }
+  public void setK8sPassword(String k8sPassword) {
+    this.k8sPassword = k8sPassword;
+  }
 
-    public String getExcludePackages() {
-        return excludePackages;
-    }
+  public String getK8sImage() {
+    return k8sImage;
+  }
 
-    public void setExcludePackages(String excludePackages) {
-        this.excludePackages = excludePackages;
-    }
+  public void setK8sImage(String k8sImage) {
+    this.k8sImage = k8sImage;
+  }
 
-    public String getRepositories() {
-        return repositories;
-    }
+  public String getK8sDriverRequestCores() {
+    return k8sDriverRequestCores;
+  }
 
-    public void setRepositories(String repositories) {
-        this.repositories = repositories;
-    }
+  public void setK8sDriverRequestCores(String k8sDriverRequestCores) {
+    this.k8sDriverRequestCores = k8sDriverRequestCores;
+  }
 
-    public String getFiles() {
-        return files;
-    }
+  public String getK8sExecutorRequestCores() {
+    return k8sExecutorRequestCores;
+  }
 
-    public void setFiles(String files) {
-        this.files = files;
-    }
+  public void setK8sExecutorRequestCores(String k8sExecutorRequestCores) {
+    this.k8sExecutorRequestCores = k8sExecutorRequestCores;
+  }
 
-    public String getArchives() {
-        return archives;
-    }
+  public String getK8sSparkUIPort() {
+    return k8sSparkUIPort;
+  }
 
-    public void setArchives(String archives) {
-        this.archives = archives;
-    }
+  public void setK8sSparkUIPort(String k8sSparkUIPort) {
+    this.k8sSparkUIPort = k8sSparkUIPort;
+  }
 
-    public Map<String, String> getConf() {
-        return conf;
-    }
+  public String getJavaHome() {
+    return javaHome;
+  }
 
-    public void setConf(Map<String, String> conf) {
-        this.conf = conf;
-    }
+  public void setJavaHome(String javaHome) {
+    this.javaHome = javaHome;
+  }
 
-    public void addAllConf(Map<String, String> conf) {
-        if (this.conf == null) {
-            setConf(conf);
-        } else {
-            this.conf.putAll(conf);
-        }
-    }
+  public String getSparkHome() {
+    return sparkHome;
+  }
 
-    public String getPropertiesFile() {
-        return propertiesFile;
-    }
+  public void setSparkHome(String sparkHome) {
+    this.sparkHome = sparkHome;
+  }
 
-    public void setPropertiesFile(String propertiesFile) {
-        this.propertiesFile = propertiesFile;
-    }
+  public String getMaster() {
+    return master;
+  }
 
-    public String getDriverMemory() {
-        return driverMemory;
-    }
+  public void setMaster(String master) {
+    this.master = master;
+  }
 
-    public void setDriverMemory(String driverMemory) {
-        this.driverMemory = driverMemory;
-    }
+  public String getDeployMode() {
+    return deployMode;
+  }
 
-    public String getDriverJavaOptions() {
-        return driverJavaOptions;
-    }
+  public void setDeployMode(String deployMode) {
+    this.deployMode = deployMode;
+  }
 
-    public void setDriverJavaOptions(String driverJavaOptions) {
-        this.driverJavaOptions = driverJavaOptions;
-    }
+  public String getAppResource() {
+    return appResource;
+  }
 
-    public String getDriverLibraryPath() {
-        return driverLibraryPath;
-    }
+  public void setAppResource(String appResource) {
+    this.appResource = appResource;
+  }
 
-    public void setDriverLibraryPath(String driverLibraryPath) {
-        this.driverLibraryPath = driverLibraryPath;
-    }
+  public String getAppName() {
+    return appName;
+  }
 
-    public String getDriverClassPath() {
-        return driverClassPath;
-    }
+  public void setAppName(String appName) {
+    this.appName = appName;
+  }
 
-    public void setDriverClassPath(String driverClassPath) {
-        this.driverClassPath = driverClassPath;
-    }
+  public String getJars() {
+    return jars;
+  }
 
-    public String getExecutorMemory() {
-        return executorMemory;
-    }
+  public void setJars(String jars) {
+    this.jars = jars;
+  }
 
-    public void setExecutorMemory(String executorMemory) {
-        this.executorMemory = executorMemory;
-    }
+  public String getPackages() {
+    return packages;
+  }
 
-    public String getProxyUser() {
-        return proxyUser;
-    }
+  public void setPackages(String packages) {
+    this.packages = packages;
+  }
 
-    public void setProxyUser(String proxyUser) {
-        this.proxyUser = proxyUser;
-    }
+  public String getExcludePackages() {
+    return excludePackages;
+  }
 
-    public boolean isVerbose() {
-        return verbose;
-    }
+  public void setExcludePackages(String excludePackages) {
+    this.excludePackages = excludePackages;
+  }
 
-    public void setVerbose(boolean verbose) {
-        this.verbose = verbose;
-    }
+  public String getRepositories() {
+    return repositories;
+  }
 
-    public Integer getDriverCores() {
-        return driverCores;
-    }
+  public void setRepositories(String repositories) {
+    this.repositories = repositories;
+  }
 
-    public void setDriverCores(Integer driverCores) {
-        this.driverCores = driverCores;
-    }
+  public String getFiles() {
+    return files;
+  }
 
-    public String getTotalExecutorCores() {
-        return totalExecutorCores;
-    }
+  public void setFiles(String files) {
+    this.files = files;
+  }
 
-    public void setTotalExecutorCores(String totalExecutorCores) {
-        this.totalExecutorCores = totalExecutorCores;
-    }
+  public String getArchives() {
+    return archives;
+  }
 
-    public Integer getExecutorCores() {
-        return executorCores;
-    }
+  public void setArchives(String archives) {
+    this.archives = archives;
+  }
 
-    public void setExecutorCores(Integer executorCores) {
-        this.executorCores = executorCores;
-    }
+  public Map<String, String> getConf() {
+    return conf;
+  }
 
-    public Integer getNumExecutors() {
-        return numExecutors;
-    }
+  public void setConf(Map<String, String> conf) {
+    this.conf = conf;
+  }
 
-    public void setNumExecutors(Integer numExecutors) {
-        this.numExecutors = numExecutors;
+  public void addAllConf(Map<String, String> conf) {
+    if (this.conf == null) {
+      setConf(conf);
+    } else {
+      this.conf.putAll(conf);
     }
+  }
 
-    public String getPrincipal() {
-        return principal;
-    }
+  public String getPropertiesFile() {
+    return propertiesFile;
+  }
 
-    public void setPrincipal(String principal) {
-        this.principal = principal;
-    }
+  public void setPropertiesFile(String propertiesFile) {
+    this.propertiesFile = propertiesFile;
+  }
 
-    public String getKeytab() {
-        return keytab;
-    }
+  public String getDriverMemory() {
+    return driverMemory;
+  }
 
-    public void setKeytab(String keytab) {
-        this.keytab = keytab;
-    }
+  public void setDriverMemory(String driverMemory) {
+    this.driverMemory = driverMemory;
+  }
 
-    public String getQueue() {
-        return queue;
-    }
+  public String getDriverJavaOptions() {
+    return driverJavaOptions;
+  }
 
-    public void setQueue(String queue) {
-        this.queue = queue;
-    }
+  public void setDriverJavaOptions(String driverJavaOptions) {
+    this.driverJavaOptions = driverJavaOptions;
+  }
 
-    public String getPyFiles() {
-        return pyFiles;
-    }
+  public String getDriverLibraryPath() {
+    return driverLibraryPath;
+  }
 
-    public void setPyFiles(String pyFiles) {
-        this.pyFiles = pyFiles;
-    }
+  public void setDriverLibraryPath(String driverLibraryPath) {
+    this.driverLibraryPath = driverLibraryPath;
+  }
 
-    @Override
-    public String toString() {
-        return "SparkConfig{"
-                + "javaHome='"
-                + javaHome
-                + '\''
-                + ", sparkHome='"
-                + sparkHome
-                + '\''
-                + ", master='"
-                + master
-                + '\''
-                + ", k8sConfigFile='"
-                + k8sConfigFile
-                + '\''
-                + ", k8sServiceAccount='"
-                + k8sServiceAccount
-                + '\''
-                + ", k8sMasterUrl='"
-                + k8sMasterUrl
-                + '\''
-                + ", k8sImage='"
-                + k8sImage
-                + '\''
-                + ", k8sImagePullPolicy='"
-                + k8sImagePullPolicy
-                + '\''
-                + ", k8sLanguageType='"
-                + k8sLanguageType
-                + '\''
-                + ", k8sRestartPolicy='"
-                + k8sRestartPolicy
-                + '\''
-                + ", k8sSparkVersion='"
-                + k8sSparkVersion
-                + '\''
-                + ", k8sFileUploadPath='"
-                + k8sFileUploadPath
-                + '\''
-                + ", k8sNamespace='"
-                + k8sNamespace
-                + '\''
-                + ", k8sDriverRequestCores='"
-                + k8sDriverRequestCores
-                + '\''
-                + ", k8sExecutorRequestCores='"
-                + k8sExecutorRequestCores
-                + '\''
-                + ", k8sSparkUIPort='"
-                + k8sSparkUIPort
-                + '\''
-                + ", deployMode='"
-                + deployMode
-                + '\''
-                + ", appName='"
-                + appName
-                + '\''
-                + ", jars='"
-                + jars
-                + '\''
-                + ", packages='"
-                + packages
-                + '\''
-                + ", excludePackages='"
-                + excludePackages
-                + '\''
-                + ", repositories='"
-                + repositories
-                + '\''
-                + ", files='"
-                + files
-                + '\''
-                + ", archives='"
-                + archives
-                + '\''
-                + ", conf="
-                + conf
-                + ", propertiesFile='"
-                + propertiesFile
-                + '\''
-                + ", driverMemory='"
-                + driverMemory
-                + '\''
-                + ", driverJavaOptions='"
-                + driverJavaOptions
-                + '\''
-                + ", driverLibraryPath='"
-                + driverLibraryPath
-                + '\''
-                + ", driverClassPath='"
-                + driverClassPath
-                + '\''
-                + ", executorMemory='"
-                + executorMemory
-                + '\''
-                + ", proxyUser='"
-                + proxyUser
-                + '\''
-                + ", verbose="
-                + verbose
-                + ", driverCores="
-                + driverCores
-                + ", totalExecutorCores='"
-                + totalExecutorCores
-                + '\''
-                + ", executorCores="
-                + executorCores
-                + ", numExecutors="
-                + numExecutors
-                + ", principal='"
-                + principal
-                + '\''
-                + ", keytab='"
-                + keytab
-                + '\''
-                + ", queue='"
-                + queue
-                + '\''
-                + ", pyFiles='"
-                + pyFiles
-                + '\''
-                + '}';
-    }
+  public String getDriverClassPath() {
+    return driverClassPath;
+  }
+
+  public void setDriverClassPath(String driverClassPath) {
+    this.driverClassPath = driverClassPath;
+  }
+
+  public String getExecutorMemory() {
+    return executorMemory;
+  }
+
+  public void setExecutorMemory(String executorMemory) {
+    this.executorMemory = executorMemory;
+  }
+
+  public String getProxyUser() {
+    return proxyUser;
+  }
+
+  public void setProxyUser(String proxyUser) {
+    this.proxyUser = proxyUser;
+  }
+
+  public boolean isVerbose() {
+    return verbose;
+  }
+
+  public void setVerbose(boolean verbose) {
+    this.verbose = verbose;
+  }
+
+  public Integer getDriverCores() {
+    return driverCores;
+  }
+
+  public void setDriverCores(Integer driverCores) {
+    this.driverCores = driverCores;
+  }
+
+  public String getTotalExecutorCores() {
+    return totalExecutorCores;
+  }
+
+  public void setTotalExecutorCores(String totalExecutorCores) {
+    this.totalExecutorCores = totalExecutorCores;
+  }
+
+  public Integer getExecutorCores() {
+    return executorCores;
+  }
+
+  public void setExecutorCores(Integer executorCores) {
+    this.executorCores = executorCores;
+  }
+
+  public Integer getNumExecutors() {
+    return numExecutors;
+  }
+
+  public void setNumExecutors(Integer numExecutors) {
+    this.numExecutors = numExecutors;
+  }
+
+  public String getPrincipal() {
+    return principal;
+  }
+
+  public void setPrincipal(String principal) {
+    this.principal = principal;
+  }
+
+  public String getKeytab() {
+    return keytab;
+  }
+
+  public void setKeytab(String keytab) {
+    this.keytab = keytab;
+  }
+
+  public String getQueue() {
+    return queue;
+  }
+
+  public void setQueue(String queue) {
+    this.queue = queue;
+  }
+
+  public String getPyFiles() {
+    return pyFiles;
+  }
+
+  public void setPyFiles(String pyFiles) {
+    this.pyFiles = pyFiles;
+  }
+
+  @Override
+  public String toString() {
+    return "SparkConfig{"
+        + "javaHome='"
+        + javaHome
+        + '\''
+        + ", sparkHome='"
+        + sparkHome
+        + '\''
+        + ", master='"
+        + master
+        + '\''
+        + ", k8sConfigFile='"
+        + k8sConfigFile
+        + '\''
+        + ", k8sServiceAccount='"
+        + k8sServiceAccount
+        + '\''
+        + ", k8sMasterUrl='"
+        + k8sMasterUrl
+        + '\''
+        + ", k8sImage='"
+        + k8sImage
+        + '\''
+        + ", k8sImagePullPolicy='"
+        + k8sImagePullPolicy
+        + '\''
+        + ", k8sLanguageType='"
+        + k8sLanguageType
+        + '\''
+        + ", k8sRestartPolicy='"
+        + k8sRestartPolicy
+        + '\''
+        + ", k8sSparkVersion='"
+        + k8sSparkVersion
+        + '\''
+        + ", k8sFileUploadPath='"
+        + k8sFileUploadPath
+        + '\''
+        + ", k8sNamespace='"
+        + k8sNamespace
+        + '\''
+        + ", k8sDriverRequestCores='"
+        + k8sDriverRequestCores
+        + '\''
+        + ", k8sExecutorRequestCores='"
+        + k8sExecutorRequestCores
+        + '\''
+        + ", k8sSparkUIPort='"
+        + k8sSparkUIPort
+        + '\''
+        + ", deployMode='"
+        + deployMode
+        + '\''
+        + ", appName='"
+        + appName
+        + '\''
+        + ", jars='"
+        + jars
+        + '\''
+        + ", packages='"
+        + packages
+        + '\''
+        + ", excludePackages='"
+        + excludePackages
+        + '\''
+        + ", repositories='"
+        + repositories
+        + '\''
+        + ", files='"
+        + files
+        + '\''
+        + ", archives='"
+        + archives
+        + '\''
+        + ", conf="
+        + conf
+        + ", propertiesFile='"
+        + propertiesFile
+        + '\''
+        + ", driverMemory='"
+        + driverMemory
+        + '\''
+        + ", driverJavaOptions='"
+        + driverJavaOptions
+        + '\''
+        + ", driverLibraryPath='"
+        + driverLibraryPath
+        + '\''
+        + ", driverClassPath='"
+        + driverClassPath
+        + '\''
+        + ", executorMemory='"
+        + executorMemory
+        + '\''
+        + ", proxyUser='"
+        + proxyUser
+        + '\''
+        + ", verbose="
+        + verbose
+        + ", driverCores="
+        + driverCores
+        + ", totalExecutorCores='"
+        + totalExecutorCores
+        + '\''
+        + ", executorCores="
+        + executorCores
+        + ", numExecutors="
+        + numExecutors
+        + ", principal='"
+        + principal
+        + '\''
+        + ", keytab='"
+        + keytab
+        + '\''
+        + ", queue='"
+        + queue
+        + '\''
+        + ", pyFiles='"
+        + pyFiles
+        + '\''
+        + '}';
+  }
 }

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/context/SparkConfig.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/context/SparkConfig.java
@@ -24,540 +24,548 @@ import java.util.Map;
 
 public class SparkConfig {
 
-  private String javaHome; // ("")
-  private String sparkHome; // ("")
-  private String master = "yarn"; // ("yarn")
+    private String javaHome; // ("")
+    private String sparkHome; // ("")
+    private String master = "yarn"; // ("yarn")
 
-  private String k8sConfigFile;
+    private String k8sConfigFile;
 
-  private String k8sServiceAccount;
+    private String k8sServiceAccount;
 
-  private String k8sMasterUrl;
+    private String k8sMasterUrl;
 
-  private String k8sUsername;
+    private String k8sUsername;
 
-  private String k8sPassword;
+    private String k8sPassword;
 
-  private String k8sImage;
+    private String k8sImage;
 
-  private String k8sImagePullPolicy;
+    private String k8sImagePullPolicy;
 
-  private String k8sLanguageType;
+    private String k8sLanguageType;
 
-  private String k8sRestartPolicy;
+    private String k8sRestartPolicy;
 
-  private String k8sSparkVersion;
+    private String k8sSparkVersion;
 
-  private String k8sNamespace;
-  private String k8sFileUploadPath;
+    private String k8sNamespace;
+    private String k8sFileUploadPath;
 
-  private String k8sDriverRequestCores;
-  private String k8sExecutorRequestCores;
-  private String k8sSparkUIPort;
-  private String deployMode = "client"; // ("client") // todo cluster
-  private String appResource; // ("")
-  private String appName; // ("")
-  private String jars; // ("--jars", "")
-  private String packages; // ("--packages", "")
-  private String excludePackages; // ("--exclude-packages", "")
-  private String repositories; // ("--repositories", "")
-  private String files; // ("--files", "")
-  private String archives; // ("--archives", "")
-  private Map<String, String> conf = new HashMap<>(); // ("", "")
-  private String propertiesFile; // ("")
-  private String driverMemory; // ("--driver-memory", "")
-  private String driverJavaOptions; // ("--driver-java-options", "")
-  private String driverLibraryPath; // ("--driver-library-path", "")
-  private String driverClassPath; // ("--driver-class-path", "")
-  private String executorMemory; // ("--executor-memory", "")
-  private String proxyUser; // ("--proxy-user", "")
-  private boolean verbose = false; // (false)
-  private Integer driverCores; // ("--driver-cores", "") // Cluster deploy mode only
-  private String totalExecutorCores; // ("--total-executor-cores", "")
-  private Integer executorCores; // ("--executor-cores", "")
-  private Integer numExecutors; // ("--num-executors", "")
-  private String principal; // ("--principal", "")
-  private String keytab; // ("--keytab", "")
-  private String queue; // ("--queue", "")
-  private String pyFiles; // ("--py-files", "")
+    private String k8sDriverRequestCores;
+    private String k8sExecutorRequestCores;
+    private String k8sSparkUIPort;
+    private String deployMode = "client"; // ("client") // todo cluster
+    private String appResource; // ("")
+    private String appName; // ("")
+    private String jars; // ("--jars", "")
+    private String packages; // ("--packages", "")
+    private String excludePackages; // ("--exclude-packages", "")
+    private String repositories; // ("--repositories", "")
+    private String files; // ("--files", "")
+    private String archives; // ("--archives", "")
+    private Map<String, String> conf = new HashMap<>(); // ("", "")
+    private String propertiesFile; // ("")
+    private String driverMemory; // ("--driver-memory", "")
+    private String driverJavaOptions; // ("--driver-java-options", "")
+    private String driverLibraryPath; // ("--driver-library-path", "")
+    private String driverClassPath; // ("--driver-class-path", "")
+    private String executorMemory; // ("--executor-memory", "")
+    private String proxyUser; // ("--proxy-user", "")
+    private boolean verbose = false; // (false)
+    private Integer driverCores; // ("--driver-cores", "") // Cluster deploy mode only
+    private String totalExecutorCores; // ("--total-executor-cores", "")
+    private Integer executorCores; // ("--executor-cores", "")
+    private Integer numExecutors; // ("--num-executors", "")
+    private String principal; // ("--principal", "")
+    private String keytab; // ("--keytab", "")
+    private String queue; // ("--queue", "")
+    private String pyFiles; // ("--py-files", "")
 
-  public String getK8sFileUploadPath() {
-    return k8sFileUploadPath;
-  }
-
-  public void setK8sFileUploadPath(String k8sFileUploadPath) {
-    this.k8sFileUploadPath = k8sFileUploadPath;
-  }
-
-  public String getK8sImagePullPolicy() {
-    return k8sImagePullPolicy;
-  }
-
-  public void setK8sImagePullPolicy(String k8sImagePullPolicy) {
-    this.k8sImagePullPolicy = k8sImagePullPolicy;
-  }
-
-  public String getK8sLanguageType() {
-    return k8sLanguageType;
-  }
-
-  public void setK8sLanguageType(String k8sLanguageType) {
-    this.k8sLanguageType = k8sLanguageType;
-  }
-
-  public String getK8sRestartPolicy() {
-    return k8sRestartPolicy;
-  }
-
-  public void setK8sRestartPolicy(String k8sRestartPolicy) {
-    this.k8sRestartPolicy = k8sRestartPolicy;
-  }
-
-  public String getK8sSparkVersion() {
-    return k8sSparkVersion;
-  }
-
-  public void setK8sSparkVersion(String k8sSparkVersion) {
-    this.k8sSparkVersion = k8sSparkVersion;
-  }
-
-  public String getK8sNamespace() {
-    return k8sNamespace;
-  }
-
-  public void setK8sNamespace(String k8sNamespace) {
-    this.k8sNamespace = k8sNamespace;
-  }
-
-  public String getK8sMasterUrl() {
-    return k8sMasterUrl;
-  }
-
-  public String getK8sConfigFile() {
-    return k8sConfigFile;
-  }
-
-  public void setK8sConfigFile(String k8sConfigFile) {
-    if (StringUtils.isNotBlank(k8sConfigFile) && k8sConfigFile.startsWith("~")) {
-      String user = System.getProperty("user.home");
-      k8sConfigFile = k8sConfigFile.replaceFirst("~", user);
+    public String getK8sFileUploadPath() {
+        return k8sFileUploadPath;
     }
-    this.k8sConfigFile = k8sConfigFile;
-  }
-
-  public String getK8sServiceAccount() {
-    return k8sServiceAccount;
-  }
-
-  public void setK8sServiceAccount(String k8sServiceAccount) {
-    this.k8sServiceAccount = k8sServiceAccount;
-  }
-
-  public void setK8sMasterUrl(String k8sMasterUrl) {
-    this.k8sMasterUrl = k8sMasterUrl;
-  }
-
-  public String getK8sUsername() {
-    return k8sUsername;
-  }
-
-  public void setK8sUsername(String k8sUsername) {
-    this.k8sUsername = k8sUsername;
-  }
-
-  public String getK8sPassword() {
-    return k8sPassword;
-  }
-
-  public void setK8sPassword(String k8sPassword) {
-    this.k8sPassword = k8sPassword;
-  }
-
-  public String getK8sImage() {
-    return k8sImage;
-  }
-
-  public void setK8sImage(String k8sImage) {
-    this.k8sImage = k8sImage;
-  }
-
-  public String getK8sDriverRequestCores() {
-    return k8sDriverRequestCores;
-  }
-
-  public void setK8sDriverRequestCores(String k8sDriverRequestCores) {
-    this.k8sDriverRequestCores = k8sDriverRequestCores;
-  }
-
-  public String getK8sExecutorRequestCores() {
-    return k8sExecutorRequestCores;
-  }
-
-  public void setK8sExecutorRequestCores(String k8sExecutorRequestCores) {
-    this.k8sExecutorRequestCores = k8sExecutorRequestCores;
-  }
-
-  public String getK8sSparkUIPort() {
-    return k8sSparkUIPort;
-  }
-
-  public void setK8sSparkUIPort(String k8sSparkUIPort) {
-    this.k8sSparkUIPort = k8sSparkUIPort;
-  }
-
-  public String getJavaHome() {
-    return javaHome;
-  }
-
-  public void setJavaHome(String javaHome) {
-    this.javaHome = javaHome;
-  }
-
-  public String getSparkHome() {
-    return sparkHome;
-  }
-
-  public void setSparkHome(String sparkHome) {
-    this.sparkHome = sparkHome;
-  }
-
-  public String getMaster() {
-    return master;
-  }
-
-  public void setMaster(String master) {
-    this.master = master;
-  }
-
-  public String getDeployMode() {
-    return deployMode;
-  }
-
-  public void setDeployMode(String deployMode) {
-    this.deployMode = deployMode;
-  }
-
-  public String getAppResource() {
-    return appResource;
-  }
-
-  public void setAppResource(String appResource) {
-    this.appResource = appResource;
-  }
-
-  public String getAppName() {
-    return appName;
-  }
-
-  public void setAppName(String appName) {
-    this.appName = appName;
-  }
-
-  public String getJars() {
-    return jars;
-  }
-
-  public void setJars(String jars) {
-    this.jars = jars;
-  }
-
-  public String getPackages() {
-    return packages;
-  }
-
-  public void setPackages(String packages) {
-    this.packages = packages;
-  }
-
-  public String getExcludePackages() {
-    return excludePackages;
-  }
-
-  public void setExcludePackages(String excludePackages) {
-    this.excludePackages = excludePackages;
-  }
-
-  public String getRepositories() {
-    return repositories;
-  }
-
-  public void setRepositories(String repositories) {
-    this.repositories = repositories;
-  }
-
-  public String getFiles() {
-    return files;
-  }
-
-  public void setFiles(String files) {
-    this.files = files;
-  }
-
-  public String getArchives() {
-    return archives;
-  }
-
-  public void setArchives(String archives) {
-    this.archives = archives;
-  }
-
-  public Map<String, String> getConf() {
-    return conf;
-  }
-
-  public void setConf(Map<String, String> conf) {
-    this.conf = conf;
-  }
-
-  public String getPropertiesFile() {
-    return propertiesFile;
-  }
-
-  public void setPropertiesFile(String propertiesFile) {
-    this.propertiesFile = propertiesFile;
-  }
-
-  public String getDriverMemory() {
-    return driverMemory;
-  }
-
-  public void setDriverMemory(String driverMemory) {
-    this.driverMemory = driverMemory;
-  }
-
-  public String getDriverJavaOptions() {
-    return driverJavaOptions;
-  }
-
-  public void setDriverJavaOptions(String driverJavaOptions) {
-    this.driverJavaOptions = driverJavaOptions;
-  }
-
-  public String getDriverLibraryPath() {
-    return driverLibraryPath;
-  }
-
-  public void setDriverLibraryPath(String driverLibraryPath) {
-    this.driverLibraryPath = driverLibraryPath;
-  }
-
-  public String getDriverClassPath() {
-    return driverClassPath;
-  }
-
-  public void setDriverClassPath(String driverClassPath) {
-    this.driverClassPath = driverClassPath;
-  }
-
-  public String getExecutorMemory() {
-    return executorMemory;
-  }
-
-  public void setExecutorMemory(String executorMemory) {
-    this.executorMemory = executorMemory;
-  }
-
-  public String getProxyUser() {
-    return proxyUser;
-  }
-
-  public void setProxyUser(String proxyUser) {
-    this.proxyUser = proxyUser;
-  }
-
-  public boolean isVerbose() {
-    return verbose;
-  }
-
-  public void setVerbose(boolean verbose) {
-    this.verbose = verbose;
-  }
-
-  public Integer getDriverCores() {
-    return driverCores;
-  }
-
-  public void setDriverCores(Integer driverCores) {
-    this.driverCores = driverCores;
-  }
-
-  public String getTotalExecutorCores() {
-    return totalExecutorCores;
-  }
-
-  public void setTotalExecutorCores(String totalExecutorCores) {
-    this.totalExecutorCores = totalExecutorCores;
-  }
-
-  public Integer getExecutorCores() {
-    return executorCores;
-  }
-
-  public void setExecutorCores(Integer executorCores) {
-    this.executorCores = executorCores;
-  }
-
-  public Integer getNumExecutors() {
-    return numExecutors;
-  }
-
-  public void setNumExecutors(Integer numExecutors) {
-    this.numExecutors = numExecutors;
-  }
-
-  public String getPrincipal() {
-    return principal;
-  }
-
-  public void setPrincipal(String principal) {
-    this.principal = principal;
-  }
-
-  public String getKeytab() {
-    return keytab;
-  }
-
-  public void setKeytab(String keytab) {
-    this.keytab = keytab;
-  }
-
-  public String getQueue() {
-    return queue;
-  }
-
-  public void setQueue(String queue) {
-    this.queue = queue;
-  }
-
-  public String getPyFiles() {
-    return pyFiles;
-  }
-
-  public void setPyFiles(String pyFiles) {
-    this.pyFiles = pyFiles;
-  }
-
-  @Override
-  public String toString() {
-    return "SparkConfig{"
-        + "javaHome='"
-        + javaHome
-        + '\''
-        + ", sparkHome='"
-        + sparkHome
-        + '\''
-        + ", master='"
-        + master
-        + '\''
-        + ", k8sConfigFile='"
-        + k8sConfigFile
-        + '\''
-        + ", k8sServiceAccount='"
-        + k8sServiceAccount
-        + '\''
-        + ", k8sMasterUrl='"
-        + k8sMasterUrl
-        + '\''
-        + ", k8sImage='"
-        + k8sImage
-        + '\''
-        + ", k8sImagePullPolicy='"
-        + k8sImagePullPolicy
-        + '\''
-        + ", k8sLanguageType='"
-        + k8sLanguageType
-        + '\''
-        + ", k8sRestartPolicy='"
-        + k8sRestartPolicy
-        + '\''
-        + ", k8sSparkVersion='"
-        + k8sSparkVersion
-        + '\''
-        + ", k8sFileUploadPath='"
-        + k8sFileUploadPath
-        + '\''
-        + ", k8sNamespace='"
-        + k8sNamespace
-        + '\''
-        + ", k8sDriverRequestCores='"
-        + k8sDriverRequestCores
-        + '\''
-        + ", k8sExecutorRequestCores='"
-        + k8sExecutorRequestCores
-        + '\''
-        + ", k8sSparkUIPort='"
-        + k8sSparkUIPort
-        + '\''
-        + ", deployMode='"
-        + deployMode
-        + '\''
-        + ", appName='"
-        + appName
-        + '\''
-        + ", jars='"
-        + jars
-        + '\''
-        + ", packages='"
-        + packages
-        + '\''
-        + ", excludePackages='"
-        + excludePackages
-        + '\''
-        + ", repositories='"
-        + repositories
-        + '\''
-        + ", files='"
-        + files
-        + '\''
-        + ", archives='"
-        + archives
-        + '\''
-        + ", conf="
-        + conf
-        + ", propertiesFile='"
-        + propertiesFile
-        + '\''
-        + ", driverMemory='"
-        + driverMemory
-        + '\''
-        + ", driverJavaOptions='"
-        + driverJavaOptions
-        + '\''
-        + ", driverLibraryPath='"
-        + driverLibraryPath
-        + '\''
-        + ", driverClassPath='"
-        + driverClassPath
-        + '\''
-        + ", executorMemory='"
-        + executorMemory
-        + '\''
-        + ", proxyUser='"
-        + proxyUser
-        + '\''
-        + ", verbose="
-        + verbose
-        + ", driverCores="
-        + driverCores
-        + ", totalExecutorCores='"
-        + totalExecutorCores
-        + '\''
-        + ", executorCores="
-        + executorCores
-        + ", numExecutors="
-        + numExecutors
-        + ", principal='"
-        + principal
-        + '\''
-        + ", keytab='"
-        + keytab
-        + '\''
-        + ", queue='"
-        + queue
-        + '\''
-        + ", pyFiles='"
-        + pyFiles
-        + '\''
-        + '}';
-  }
+
+    public void setK8sFileUploadPath(String k8sFileUploadPath) {
+        this.k8sFileUploadPath = k8sFileUploadPath;
+    }
+
+    public String getK8sImagePullPolicy() {
+        return k8sImagePullPolicy;
+    }
+
+    public void setK8sImagePullPolicy(String k8sImagePullPolicy) {
+        this.k8sImagePullPolicy = k8sImagePullPolicy;
+    }
+
+    public String getK8sLanguageType() {
+        return k8sLanguageType;
+    }
+
+    public void setK8sLanguageType(String k8sLanguageType) {
+        this.k8sLanguageType = k8sLanguageType;
+    }
+
+    public String getK8sRestartPolicy() {
+        return k8sRestartPolicy;
+    }
+
+    public void setK8sRestartPolicy(String k8sRestartPolicy) {
+        this.k8sRestartPolicy = k8sRestartPolicy;
+    }
+
+    public String getK8sSparkVersion() {
+        return k8sSparkVersion;
+    }
+
+    public void setK8sSparkVersion(String k8sSparkVersion) {
+        this.k8sSparkVersion = k8sSparkVersion;
+    }
+
+    public String getK8sNamespace() {
+        return k8sNamespace;
+    }
+
+    public void setK8sNamespace(String k8sNamespace) {
+        this.k8sNamespace = k8sNamespace;
+    }
+
+    public String getK8sMasterUrl() {
+        return k8sMasterUrl;
+    }
+
+    public String getK8sConfigFile() {
+        return k8sConfigFile;
+    }
+
+    public void setK8sConfigFile(String k8sConfigFile) {
+        if (StringUtils.isNotBlank(k8sConfigFile) && k8sConfigFile.startsWith("~")) {
+            String user = System.getProperty("user.home");
+            k8sConfigFile = k8sConfigFile.replaceFirst("~", user);
+        }
+        this.k8sConfigFile = k8sConfigFile;
+    }
+
+    public String getK8sServiceAccount() {
+        return k8sServiceAccount;
+    }
+
+    public void setK8sServiceAccount(String k8sServiceAccount) {
+        this.k8sServiceAccount = k8sServiceAccount;
+    }
+
+    public void setK8sMasterUrl(String k8sMasterUrl) {
+        this.k8sMasterUrl = k8sMasterUrl;
+    }
+
+    public String getK8sUsername() {
+        return k8sUsername;
+    }
+
+    public void setK8sUsername(String k8sUsername) {
+        this.k8sUsername = k8sUsername;
+    }
+
+    public String getK8sPassword() {
+        return k8sPassword;
+    }
+
+    public void setK8sPassword(String k8sPassword) {
+        this.k8sPassword = k8sPassword;
+    }
+
+    public String getK8sImage() {
+        return k8sImage;
+    }
+
+    public void setK8sImage(String k8sImage) {
+        this.k8sImage = k8sImage;
+    }
+
+    public String getK8sDriverRequestCores() {
+        return k8sDriverRequestCores;
+    }
+
+    public void setK8sDriverRequestCores(String k8sDriverRequestCores) {
+        this.k8sDriverRequestCores = k8sDriverRequestCores;
+    }
+
+    public String getK8sExecutorRequestCores() {
+        return k8sExecutorRequestCores;
+    }
+
+    public void setK8sExecutorRequestCores(String k8sExecutorRequestCores) {
+        this.k8sExecutorRequestCores = k8sExecutorRequestCores;
+    }
+
+    public String getK8sSparkUIPort() {
+        return k8sSparkUIPort;
+    }
+
+    public void setK8sSparkUIPort(String k8sSparkUIPort) {
+        this.k8sSparkUIPort = k8sSparkUIPort;
+    }
+
+    public String getJavaHome() {
+        return javaHome;
+    }
+
+    public void setJavaHome(String javaHome) {
+        this.javaHome = javaHome;
+    }
+
+    public String getSparkHome() {
+        return sparkHome;
+    }
+
+    public void setSparkHome(String sparkHome) {
+        this.sparkHome = sparkHome;
+    }
+
+    public String getMaster() {
+        return master;
+    }
+
+    public void setMaster(String master) {
+        this.master = master;
+    }
+
+    public String getDeployMode() {
+        return deployMode;
+    }
+
+    public void setDeployMode(String deployMode) {
+        this.deployMode = deployMode;
+    }
+
+    public String getAppResource() {
+        return appResource;
+    }
+
+    public void setAppResource(String appResource) {
+        this.appResource = appResource;
+    }
+
+    public String getAppName() {
+        return appName;
+    }
+
+    public void setAppName(String appName) {
+        this.appName = appName;
+    }
+
+    public String getJars() {
+        return jars;
+    }
+
+    public void setJars(String jars) {
+        this.jars = jars;
+    }
+
+    public String getPackages() {
+        return packages;
+    }
+
+    public void setPackages(String packages) {
+        this.packages = packages;
+    }
+
+    public String getExcludePackages() {
+        return excludePackages;
+    }
+
+    public void setExcludePackages(String excludePackages) {
+        this.excludePackages = excludePackages;
+    }
+
+    public String getRepositories() {
+        return repositories;
+    }
+
+    public void setRepositories(String repositories) {
+        this.repositories = repositories;
+    }
+
+    public String getFiles() {
+        return files;
+    }
+
+    public void setFiles(String files) {
+        this.files = files;
+    }
+
+    public String getArchives() {
+        return archives;
+    }
+
+    public void setArchives(String archives) {
+        this.archives = archives;
+    }
+
+    public Map<String, String> getConf() {
+        return conf;
+    }
+
+    public void setConf(Map<String, String> conf) {
+        this.conf = conf;
+    }
+
+    public void addAllConf(Map<String, String> conf) {
+        if (this.conf == null) {
+            setConf(conf);
+        } else {
+            this.conf.putAll(conf);
+        }
+    }
+
+    public String getPropertiesFile() {
+        return propertiesFile;
+    }
+
+    public void setPropertiesFile(String propertiesFile) {
+        this.propertiesFile = propertiesFile;
+    }
+
+    public String getDriverMemory() {
+        return driverMemory;
+    }
+
+    public void setDriverMemory(String driverMemory) {
+        this.driverMemory = driverMemory;
+    }
+
+    public String getDriverJavaOptions() {
+        return driverJavaOptions;
+    }
+
+    public void setDriverJavaOptions(String driverJavaOptions) {
+        this.driverJavaOptions = driverJavaOptions;
+    }
+
+    public String getDriverLibraryPath() {
+        return driverLibraryPath;
+    }
+
+    public void setDriverLibraryPath(String driverLibraryPath) {
+        this.driverLibraryPath = driverLibraryPath;
+    }
+
+    public String getDriverClassPath() {
+        return driverClassPath;
+    }
+
+    public void setDriverClassPath(String driverClassPath) {
+        this.driverClassPath = driverClassPath;
+    }
+
+    public String getExecutorMemory() {
+        return executorMemory;
+    }
+
+    public void setExecutorMemory(String executorMemory) {
+        this.executorMemory = executorMemory;
+    }
+
+    public String getProxyUser() {
+        return proxyUser;
+    }
+
+    public void setProxyUser(String proxyUser) {
+        this.proxyUser = proxyUser;
+    }
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    public Integer getDriverCores() {
+        return driverCores;
+    }
+
+    public void setDriverCores(Integer driverCores) {
+        this.driverCores = driverCores;
+    }
+
+    public String getTotalExecutorCores() {
+        return totalExecutorCores;
+    }
+
+    public void setTotalExecutorCores(String totalExecutorCores) {
+        this.totalExecutorCores = totalExecutorCores;
+    }
+
+    public Integer getExecutorCores() {
+        return executorCores;
+    }
+
+    public void setExecutorCores(Integer executorCores) {
+        this.executorCores = executorCores;
+    }
+
+    public Integer getNumExecutors() {
+        return numExecutors;
+    }
+
+    public void setNumExecutors(Integer numExecutors) {
+        this.numExecutors = numExecutors;
+    }
+
+    public String getPrincipal() {
+        return principal;
+    }
+
+    public void setPrincipal(String principal) {
+        this.principal = principal;
+    }
+
+    public String getKeytab() {
+        return keytab;
+    }
+
+    public void setKeytab(String keytab) {
+        this.keytab = keytab;
+    }
+
+    public String getQueue() {
+        return queue;
+    }
+
+    public void setQueue(String queue) {
+        this.queue = queue;
+    }
+
+    public String getPyFiles() {
+        return pyFiles;
+    }
+
+    public void setPyFiles(String pyFiles) {
+        this.pyFiles = pyFiles;
+    }
+
+    @Override
+    public String toString() {
+        return "SparkConfig{"
+                + "javaHome='"
+                + javaHome
+                + '\''
+                + ", sparkHome='"
+                + sparkHome
+                + '\''
+                + ", master='"
+                + master
+                + '\''
+                + ", k8sConfigFile='"
+                + k8sConfigFile
+                + '\''
+                + ", k8sServiceAccount='"
+                + k8sServiceAccount
+                + '\''
+                + ", k8sMasterUrl='"
+                + k8sMasterUrl
+                + '\''
+                + ", k8sImage='"
+                + k8sImage
+                + '\''
+                + ", k8sImagePullPolicy='"
+                + k8sImagePullPolicy
+                + '\''
+                + ", k8sLanguageType='"
+                + k8sLanguageType
+                + '\''
+                + ", k8sRestartPolicy='"
+                + k8sRestartPolicy
+                + '\''
+                + ", k8sSparkVersion='"
+                + k8sSparkVersion
+                + '\''
+                + ", k8sFileUploadPath='"
+                + k8sFileUploadPath
+                + '\''
+                + ", k8sNamespace='"
+                + k8sNamespace
+                + '\''
+                + ", k8sDriverRequestCores='"
+                + k8sDriverRequestCores
+                + '\''
+                + ", k8sExecutorRequestCores='"
+                + k8sExecutorRequestCores
+                + '\''
+                + ", k8sSparkUIPort='"
+                + k8sSparkUIPort
+                + '\''
+                + ", deployMode='"
+                + deployMode
+                + '\''
+                + ", appName='"
+                + appName
+                + '\''
+                + ", jars='"
+                + jars
+                + '\''
+                + ", packages='"
+                + packages
+                + '\''
+                + ", excludePackages='"
+                + excludePackages
+                + '\''
+                + ", repositories='"
+                + repositories
+                + '\''
+                + ", files='"
+                + files
+                + '\''
+                + ", archives='"
+                + archives
+                + '\''
+                + ", conf="
+                + conf
+                + ", propertiesFile='"
+                + propertiesFile
+                + '\''
+                + ", driverMemory='"
+                + driverMemory
+                + '\''
+                + ", driverJavaOptions='"
+                + driverJavaOptions
+                + '\''
+                + ", driverLibraryPath='"
+                + driverLibraryPath
+                + '\''
+                + ", driverClassPath='"
+                + driverClassPath
+                + '\''
+                + ", executorMemory='"
+                + executorMemory
+                + '\''
+                + ", proxyUser='"
+                + proxyUser
+                + '\''
+                + ", verbose="
+                + verbose
+                + ", driverCores="
+                + driverCores
+                + ", totalExecutorCores='"
+                + totalExecutorCores
+                + '\''
+                + ", executorCores="
+                + executorCores
+                + ", numExecutors="
+                + numExecutors
+                + ", principal='"
+                + principal
+                + '\''
+                + ", keytab='"
+                + keytab
+                + '\''
+                + ", queue='"
+                + queue
+                + '\''
+                + ", pyFiles='"
+                + pyFiles
+                + '\''
+                + '}';
+    }
 }

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/YarnApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/YarnApplicationClusterDescriptorAdapter.java
@@ -69,6 +69,9 @@ public class YarnApplicationClusterDescriptorAdapter extends ClusterDescriptorAd
     addSparkArg(sparkLauncher, "--principal", sparkConfig.getPrincipal());
     addSparkArg(sparkLauncher, "--keytab", sparkConfig.getKeytab());
     addSparkArg(sparkLauncher, "--queue", sparkConfig.getQueue());
+    sparkConfig
+            .getConf()
+            .forEach((key, value) -> addSparkArg(sparkLauncher, "--conf", key + "=" + value));
     sparkLauncher.setAppResource(sparkConfig.getAppResource());
     sparkLauncher.setMainClass(mainClass);
     Arrays.stream(args.split("\\s+"))

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/YarnApplicationClusterDescriptorAdapter.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/client/deployment/YarnApplicationClusterDescriptorAdapter.java
@@ -70,8 +70,8 @@ public class YarnApplicationClusterDescriptorAdapter extends ClusterDescriptorAd
     addSparkArg(sparkLauncher, "--keytab", sparkConfig.getKeytab());
     addSparkArg(sparkLauncher, "--queue", sparkConfig.getQueue());
     sparkConfig
-            .getConf()
-            .forEach((key, value) -> addSparkArg(sparkLauncher, "--conf", key + "=" + value));
+        .getConf()
+        .forEach((key, value) -> addSparkArg(sparkLauncher, "--conf", key + "=" + value));
     sparkLauncher.setAppResource(sparkConfig.getAppResource());
     sparkLauncher.setMainClass(mainClass);
     Arrays.stream(args.split("\\s+"))

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/hooks/SparkContainerizationEngineConnHook.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/hooks/SparkContainerizationEngineConnHook.java
@@ -74,13 +74,9 @@ public class SparkContainerizationEngineConnHook implements EngineConnHook {
 
   @Override
   public void afterEngineServerStartFailed(
-      EngineCreationContext engineCreationContext, Throwable throwable) {
-    EngineConnHook.super.afterEngineServerStartFailed(engineCreationContext, throwable);
-  }
+      EngineCreationContext engineCreationContext, Throwable throwable) {}
 
   @Override
   public void afterEngineServerStartSuccess(
-      EngineCreationContext engineCreationContext, EngineConn engineConn) {
-    EngineConnHook.super.afterEngineServerStartSuccess(engineCreationContext, engineConn);
-  }
+      EngineCreationContext engineCreationContext, EngineConn engineConn) {}
 }

--- a/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/hooks/SparkContainerizationEngineConnHook.java
+++ b/linkis-engineconn-plugins/spark/src/main/java/org/apache/linkis/engineplugin/spark/hooks/SparkContainerizationEngineConnHook.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.hooks;
+
+import org.apache.linkis.engineconn.common.creation.EngineCreationContext;
+import org.apache.linkis.engineconn.common.engineconn.EngineConn;
+import org.apache.linkis.engineconn.common.hook.EngineConnHook;
+import org.apache.linkis.engineplugin.spark.config.SparkConfiguration;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SparkContainerizationEngineConnHook implements EngineConnHook {
+  private static final Logger logger =
+      LoggerFactory.getLogger(SparkContainerizationEngineConnHook.class);
+
+  @Override
+  public void beforeCreateEngineConn(EngineCreationContext engineCreationContext) {
+    Map<String, String> options = engineCreationContext.getOptions();
+    String mappingHost =
+        SparkConfiguration.ENGINE_CONN_CONTAINERIZATION_MAPPING_HOST().getValue(options);
+    String mappingPorts =
+        SparkConfiguration.ENGINE_CONN_CONTAINERIZATION_MAPPING_PORTS().getValue(options);
+    List<String> mappingPortList =
+        Arrays.stream(mappingPorts.trim().split(","))
+            .filter(StringUtils::isNoneEmpty)
+            .collect(Collectors.toList());
+
+    if (mappingPortList.size() == 2) {
+      logger.info(
+          "加载spark容器化配置, spark.driver.host={}, spark.driver.port={}, spark.driver.blockManager.port={}",
+          mappingHost,
+          mappingPortList.get(0),
+          mappingPortList.get(1));
+      options.put(SparkConfiguration.SPARK_DRIVER_HOST().key(), mappingHost);
+      options.put(
+          SparkConfiguration.SPARK_DRIVER_BIND_ADDRESS().key(),
+          SparkConfiguration.SPARK_DRIVER_BIND_ADDRESS().defaultValue());
+      options.put(SparkConfiguration.SPARK_DRIVER_PORT().key(), mappingPortList.get(0));
+      options.put(
+          SparkConfiguration.SPARK_DRIVER_BLOCK_MANAGER_PORT().key(), mappingPortList.get(1));
+    }
+  }
+
+  @Override
+  public void beforeExecutionExecute(
+      EngineCreationContext engineCreationContext, EngineConn engineConn) {}
+
+  @Override
+  public void afterExecutionExecute(
+      EngineCreationContext engineCreationContext, EngineConn engineConn) {}
+
+  @Override
+  public void afterEngineServerStartFailed(
+      EngineCreationContext engineCreationContext, Throwable throwable) {
+    EngineConnHook.super.afterEngineServerStartFailed(engineCreationContext, throwable);
+  }
+
+  @Override
+  public void afterEngineServerStartSuccess(
+      EngineCreationContext engineCreationContext, EngineConn engineConn) {
+    EngineConnHook.super.afterEngineServerStartSuccess(engineCreationContext, engineConn);
+  }
+}

--- a/linkis-engineconn-plugins/spark/src/main/resources/linkis-engineconn.properties
+++ b/linkis-engineconn-plugins/spark/src/main/resources/linkis-engineconn.properties
@@ -24,7 +24,7 @@ wds.linkis.engineconn.debug.enable=true
 
 wds.linkis.engineconn.plugin.default.class=org.apache.linkis.engineplugin.spark.SparkEngineConnPlugin
 
-wds.linkis.engine.connector.hooks=org.apache.linkis.engineconn.computation.executor.hook.ComputationEngineConnHook,org.apache.linkis.engineconn.computation.executor.hook.PyUdfEngineHook,org.apache.linkis.engineconn.computation.executor.hook.ScalaUdfEngineHook,org.apache.linkis.engineconn.computation.executor.hook.JarUdfEngineHook,org.apache.linkis.engineconn.computation.executor.hook.SparkInitSQLHook,org.apache.linkis.engineconn.computation.executor.hook.PythonSparkEngineHook
+wds.linkis.engine.connector.hooks=org.apache.linkis.engineconn.computation.executor.hook.ComputationEngineConnHook,org.apache.linkis.engineconn.computation.executor.hook.PyUdfEngineHook,org.apache.linkis.engineconn.computation.executor.hook.ScalaUdfEngineHook,org.apache.linkis.engineconn.computation.executor.hook.JarUdfEngineHook,org.apache.linkis.engineconn.computation.executor.hook.SparkInitSQLHook,org.apache.linkis.engineconn.computation.executor.hook.PythonSparkEngineHook,org.apache.linkis.engineplugin.spark.hooks.SparkContainerizationEngineConnHook
 
 linkis.spark.once.yarn.restful.url=http://127.0.0.1:8088
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
@@ -185,6 +185,20 @@ object SparkConfiguration extends Logging {
   val SCALA_PARSE_APPEND_CODE =
     CommonVars("linkis.scala.parse.append.code", "val linkisVar=1").getValue
 
+  val ENGINE_CONN_CONTAINERIZATION_MAPPING_HOST =
+    CommonVars("linkis.engine.containerization.mapping.host", "")
+
+  val ENGINE_CONN_CONTAINERIZATION_MAPPING_PORTS =
+    CommonVars("linkis.engine.containerization.mapping.ports", "")
+
+  val SPARK_DRIVER_HOST = CommonVars[String]("spark.driver.host", "")
+
+  val SPARK_DRIVER_PORT = CommonVars[String]("spark.driver.port", "")
+
+  val SPARK_DRIVER_BIND_ADDRESS = CommonVars[String]("spark.driver.bindAddress", "0.0.0.0")
+
+  val SPARK_DRIVER_BLOCK_MANAGER_PORT = CommonVars[String]("spark.driver.blockManager.port", "")
+
   private def getMainJarName(): String = {
     val somePath = ClassUtils.jarOfClass(classOf[SparkEngineConnFactory])
     if (somePath.isDefined) {

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkEngineConnFactory.scala
@@ -137,6 +137,17 @@ class SparkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
     sparkConfig.setQueue(LINKIS_QUEUE_NAME.getValue(options))
     sparkConfig.setPyFiles(SPARK_PYTHON_FILES.getValue(options))
 
+    val conf = new util.HashMap[String, String]()
+    addSparkConf(conf, SPARK_DRIVER_HOST.key, SPARK_DRIVER_HOST.getValue(options))
+    addSparkConf(conf, SPARK_DRIVER_PORT.key, SPARK_DRIVER_PORT.getValue(options))
+    addSparkConf(conf, SPARK_DRIVER_BIND_ADDRESS.key, SPARK_DRIVER_BIND_ADDRESS.getValue(options))
+    addSparkConf(
+      conf,
+      SPARK_DRIVER_BLOCK_MANAGER_PORT.key,
+      SPARK_DRIVER_BLOCK_MANAGER_PORT.getValue(options)
+    )
+    sparkConfig.setConf(conf)
+
     logger.info(s"spark_info: ${sparkConfig}")
     sparkConfig
   }
@@ -185,6 +196,19 @@ class SparkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
     // when spark version is greater than or equal to 1.5.0
     if (master.contains("yarn")) sparkConf.set("spark.yarn.isPython", "true")
 
+    addSparkConf(sparkConf, SPARK_DRIVER_HOST.key, SPARK_DRIVER_HOST.getValue(options))
+    addSparkConf(sparkConf, SPARK_DRIVER_PORT.key, SPARK_DRIVER_PORT.getValue(options))
+    addSparkConf(
+      sparkConf,
+      SPARK_DRIVER_BIND_ADDRESS.key,
+      SPARK_DRIVER_BIND_ADDRESS.getValue(options)
+    )
+    addSparkConf(
+      sparkConf,
+      SPARK_DRIVER_BLOCK_MANAGER_PORT.key,
+      SPARK_DRIVER_BLOCK_MANAGER_PORT.getValue(options)
+    )
+
     val outputDir = createOutputDir(sparkConf)
 
     logger.info(
@@ -213,6 +237,18 @@ class SparkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
       sqlContext.setConf(kv._1, kv._2)
     }
     SparkEngineSession(sc, sqlContext, sparkSession, outputDir)
+  }
+
+  private def addSparkConf(conf: SparkConf, key: String, value: String): Unit = {
+    if (StringUtils.isNotEmpty(value)) {
+      conf.set(key, value)
+    }
+  }
+
+  private def addSparkConf(conf: JMap[String, String], key: String, value: String): Unit = {
+    if (StringUtils.isNotEmpty(value)) {
+      conf.put(key, value)
+    }
   }
 
   def createSparkSession(

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkEngineConnFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkEngineConnFactory.scala
@@ -146,7 +146,8 @@ class SparkEngineConnFactory extends MultiExecutorEngineConnFactory with Logging
       SPARK_DRIVER_BLOCK_MANAGER_PORT.key,
       SPARK_DRIVER_BLOCK_MANAGER_PORT.getValue(options)
     )
-    sparkConfig.setConf(conf)
+
+    sparkConfig.addAllConf(conf)
 
     logger.info(s"spark_info: ${sparkConfig}")
     sparkConfig


### PR DESCRIPTION
### What is the purpose of the change

Add a containerized mode to the ECM service, which allows assigning specific IPs and ports for communication with the outside world to particular engines in this mode. For instance, a Spark engine requires at least two ports: spark.driver.port and spark.driver.blockManager.port.

### Related issues/PRs

Related issues: #5199 


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.

