### PR TITLE
feat: add support for sparkmeasure

### DIFF
--- a/linkis-dist/release-docs/LICENSE
+++ b/linkis-dist/release-docs/LICENSE
@@ -600,6 +600,7 @@ See licenses/ for text of these licenses.
     (Apache License, version 2.0) seatunnel-core-flink (org.apache.seatunnel:seatunnel-core-flink:2.1.2 - https://seatunnel.apache.org)
     (Apache License, version 2.0) seatunnel-core-flink-sql (org.apache.seatunnel:seatunnel-core-flink-sql:2.1.2 - https://seatunnel.apache.org)
     (Apache License, version 2.0) seatunnel-core-spark (org.apache.seatunnel:seatunnel-core-spark:2.1.2 - https://seatunnel.apache.org)
+    (Apache License, version 2.0) spark-measure (ch.cern.sparkmeasure:spark-measure_2.12:0.24 - https://github.com/LucaCanali/sparkMeasure)
 
 ========================================================================
 Third party CDDL licenses

--- a/linkis-dist/release-docs/licenses/LICENSE-spark-measure.txt
+++ b/linkis-dist/release-docs/licenses/LICENSE-spark-measure.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/linkis-engineconn-plugins/spark/pom.xml
+++ b/linkis-engineconn-plugins/spark/pom.xml
@@ -438,6 +438,32 @@
       <groupId>ch.cern.sparkmeasure</groupId>
       <artifactId>spark-measure_2.12</artifactId>
       <version>0.24</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.xerial.snappy</groupId>
+          <artifactId>snappy-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.squareup.retrofit2</groupId>
+          <artifactId>retrofit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.msgpack</groupId>
+          <artifactId>msgpack-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.squareup.moshi</groupId>
+          <artifactId>moshi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.influxdb</groupId>
+          <artifactId>influxdb-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.squareup.retrofit2</groupId>
+          <artifactId>converter-moshi</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/linkis-engineconn-plugins/spark/pom.xml
+++ b/linkis-engineconn-plugins/spark/pom.xml
@@ -433,6 +433,12 @@
       <artifactId>kubernetes-model-core</artifactId>
       <version>${kubernetes-client.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>ch.cern.sparkmeasure</groupId>
+      <artifactId>spark-measure_2.12</artifactId>
+      <version>0.24</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
@@ -188,13 +188,16 @@ object SparkConfiguration extends Logging {
   val SCALA_PARSE_APPEND_CODE =
     CommonVars("linkis.scala.parse.append.code", "val linkisVar=1").getValue
 
-  val SPARKMEASURE_TYPE = "linkis.sparkmeasure.type"
+  val SPARKMEASURE_AGGREGATE_TYPE = "linkis.sparkmeasure.aggregate.type"
 
   val SPARKMEASURE_FLIGHT_RECORDER_TYPE =
     CommonVars[String]("linkis.sparkmeasure.flight.recorder.type", "")
 
   val SPARKMEASURE_OUTPUT_PREFIX =
-    CommonVars[String]("linkis.sparkmeasure.output.prefix", "/appcom/sparkmeasure")
+    CommonVars[String](
+      "linkis.sparkmeasure.output.prefix",
+      "/Users/zhangyuyao/Software/servers/linkis160/sparkmeasure"
+    )
 
   val SPARKMEASURE_FLIGHT_STAGE_CLASS =
     "ch.cern.sparkmeasure.FlightRecorderStageMetrics"

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
@@ -194,10 +194,7 @@ object SparkConfiguration extends Logging {
     CommonVars[String]("linkis.sparkmeasure.flight.recorder.type", "")
 
   val SPARKMEASURE_OUTPUT_PREFIX =
-    CommonVars[String](
-      "linkis.sparkmeasure.output.prefix",
-      "/Users/zhangyuyao/Software/servers/linkis160/sparkmeasure"
-    )
+    CommonVars[String]("linkis.sparkmeasure.output.prefix", "/appcom/sparkmeasure")
 
   val SPARKMEASURE_FLIGHT_STAGE_CLASS =
     "ch.cern.sparkmeasure.FlightRecorderStageMetrics"

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/config/SparkConfiguration.scala
@@ -188,6 +188,29 @@ object SparkConfiguration extends Logging {
   val SCALA_PARSE_APPEND_CODE =
     CommonVars("linkis.scala.parse.append.code", "val linkisVar=1").getValue
 
+  val SPARKMEASURE_TYPE = "linkis.sparkmeasure.type"
+
+  val SPARKMEASURE_FLIGHT_RECORDER_TYPE =
+    CommonVars[String]("linkis.sparkmeasure.flight.recorder.type", "")
+
+  val SPARKMEASURE_OUTPUT_PREFIX =
+    CommonVars[String]("linkis.sparkmeasure.output.prefix", "/appcom/sparkmeasure")
+
+  val SPARKMEASURE_FLIGHT_STAGE_CLASS =
+    "ch.cern.sparkmeasure.FlightRecorderStageMetrics"
+
+  val SPARKMEASURE_FLIGHT_TASK_CLASS = "ch.cern.sparkmeasure.FlightRecorderTaskMetrics"
+
+  val SPARKMEASURE_FLIGHT_RECORDER_KEY = "spark.extraListeners"
+
+  val SPARKMEASURE_FLIGHT_RECORDER_OUTPUT_FORMAT_KEY = "spark.sparkmeasure.outputFormat"
+
+  val SPARKMEASURE_FLIGHT_RECORDER_OUTPUT_FORMAT_JSON = "json"
+
+  val SPARKMEASURE_FLIGHT_RECORDER_OUTPUT_FORMAT_JSON_HADOOP = "json_to_hadoop"
+
+  val SPARKMEASURE_FLIGHT_RECORDER_OUTPUT_FILENAME_KEY = "spark.sparkmeasure.outputFilename"
+
   private def getMainJarName(): String = {
     val somePath = ClassUtils.jarOfClass(classOf[SparkEngineConnFactory])
     if (somePath.isDefined) {

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkSqlExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkSqlExecutor.scala
@@ -155,9 +155,6 @@ class SparkSqlExecutor(
     }
   }
 
-  /**
-   * 创建 SparkSqlMeasure 实例的辅助方法
-   */
   private def createSparkMeasure(
       engineExecutionContext: EngineExecutionContext,
       sparkEngineSession: SparkEngineSession,

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkSqlExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkSqlExecutor.scala
@@ -17,26 +17,31 @@
 
 package org.apache.linkis.engineplugin.spark.executor
 
+import org.apache.linkis.common.io.FsPath
 import org.apache.linkis.common.utils.Utils
 import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext
 import org.apache.linkis.engineplugin.spark.common.{Kind, SparkSQL}
 import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
 import org.apache.linkis.engineplugin.spark.entity.SparkEngineSession
-import org.apache.linkis.engineplugin.spark.utils.{ArrowUtils, DirectPushCache, EngineUtils}
+import org.apache.linkis.engineplugin.spark.sparkmeasure.SparkSqlMeasure
+import org.apache.linkis.engineplugin.spark.utils.{DirectPushCache, EngineUtils}
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants
 import org.apache.linkis.governance.common.paser.SQLCodeParser
 import org.apache.linkis.scheduler.executer._
+
+import org.apache.commons.lang3.ObjectUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.apache.linkis.common.io.FsPath
-import org.apache.linkis.engineplugin.spark.sparkmeasure.SparkSqlMeasure
 import org.apache.spark.sql.DataFrame
 
 import java.lang.reflect.InvocationTargetException
 import java.util
 import java.util.Date
 
-class SparkSqlExecutor(sparkEngineSession: SparkEngineSession, id: Long, options: util.Map[String, String])
-    extends SparkEngineConnExecutor(sparkEngineSession.sparkContext, id) {
+class SparkSqlExecutor(
+    sparkEngineSession: SparkEngineSession,
+    id: Long,
+    options: util.Map[String, String]
+) extends SparkEngineConnExecutor(sparkEngineSession.sparkContext, id) {
 
   override def init(): Unit = {
 
@@ -86,21 +91,29 @@ class SparkSqlExecutor(sparkEngineSession: SparkEngineSession, id: Long, options
         .setContextClassLoader(sparkEngineSession.sparkSession.sharedState.jarClassLoader)
       val extensions =
         org.apache.linkis.engineplugin.spark.extension.SparkSqlExtension.getSparkSqlExtensions()
-      val outputPrefix = SparkConfiguration.SPARKMEASURE_OUTPUT_PREFIX.getValue(options)
       val sparkMeasureType = engineExecutionContext.getProperties
-        .getOrDefault(SparkConfiguration.SPARKMEASURE_TYPE, "stage")
-        .toString
-      val outputPath = FsPath.getFsPath(
-        outputPrefix,
-        options.get("user"),
-        sparkMeasureType,
-        engineExecutionContext.getProperties.get("jobId").toString,
-        new Date().getTime.toString
-      )
-      val sparkMeasure =
-        new SparkSqlMeasure(sparkEngineSession.sparkSession, code, sparkMeasureType, outputPath)
+        .get(SparkConfiguration.SPARKMEASURE_AGGREGATE_TYPE)
+      val df = if (ObjectUtils.isNotEmpty(sparkMeasureType)) {
+        val outputPrefix = SparkConfiguration.SPARKMEASURE_OUTPUT_PREFIX.getValue(options)
+        val outputPath = FsPath.getFsPath(
+          outputPrefix,
+          options.get("user"),
+          sparkMeasureType.toString,
+          options.get("jobId"),
+          new Date().getTime.toString
+        )
+        val sparkMeasure =
+          new SparkSqlMeasure(
+            sparkEngineSession.sparkSession,
+            code,
+            sparkMeasureType.toString,
+            outputPath
+          )
 
-      val df = sparkMeasure.generatorMetrics()
+        sparkMeasure.generatorMetrics()
+      } else {
+        sparkEngineSession.sqlContext.sql(code)
+      }
 
       Utils.tryQuietly(
         extensions.foreach(

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkSqlExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkSqlExecutor.scala
@@ -38,7 +38,7 @@ import java.lang.reflect.InvocationTargetException
 import java.util
 import java.util.Date
 
-import scala.jdk.CollectionConverters.seqAsJavaListConverter
+import scala.collection.JavaConverters._
 
 import ch.cern.sparkmeasure.{StageMetrics, TaskMetrics}
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkSqlExecutorFactory.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/factory/SparkSqlExecutorFactory.scala
@@ -41,7 +41,7 @@ class SparkSqlExecutorFactory extends ComputationExecutorFactory {
   ): ComputationExecutor = {
     engineConn.getEngineConnSession match {
       case sparkEngineSession: SparkEngineSession =>
-        new SparkSqlExecutor(sparkEngineSession, id)
+        new SparkSqlExecutor(sparkEngineSession, id, engineCreationContext.getOptions)
       case _ =>
         throw NotSupportSparkSqlTypeException(INVALID_CREATE_SPARKSQL.getErrorDesc)
     }

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/sparkmeasure/SparkSqlMeasure.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/sparkmeasure/SparkSqlMeasure.scala
@@ -123,13 +123,9 @@ class SparkSqlMeasure(
   ): java.util.Map[String, Long] = {
     metrics match {
       case Left(stageMetrics) =>
-        logger.info("StageMetrics begin executed.")
         stageMetrics.aggregateStageMetricsJavaMap()
-
       case Right(taskMetrics) =>
-        logger.info("TaskMetrics begin executed.")
         taskMetrics.aggregateTaskMetricsJavaMap()
-
       case _ => new util.HashMap[String, Long]()
     }
   }

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/sparkmeasure/SparkSqlMeasure.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/sparkmeasure/SparkSqlMeasure.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.spark.sparkmeasure
+
+import org.apache.linkis.common.io.FsPath
+import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.storage.FSFactory
+import org.apache.commons.collections4.MapUtils
+import org.apache.commons.io.IOUtils
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.util
+import ch.cern.sparkmeasure.{StageMetrics, TaskMetrics}
+import com.fasterxml.jackson.databind.ObjectMapper
+
+class SparkSqlMeasure(
+    sparkSession: SparkSession,
+    sql: String,
+    metricType: String,
+    outputPath: FsPath
+) extends Logging {
+
+  private val sqlType = getDQLSqlType
+
+  def generatorMetrics(): DataFrame = {
+    var df: DataFrame = null
+    val metricsMap: java.util.Map[String, Long] = metricType match {
+      case "stage" =>
+        val metrics = StageMetrics(sparkSession)
+        sqlType match {
+          case "SELECT" =>
+            df = sparkSession.sql(sql)
+            metrics.runAndMeasure(df.show(0))
+            metrics.aggregateStageMetricsJavaMap()
+          case "INSERT" =>
+            df = metrics.runAndMeasure(sparkSession.sql(sql))
+            metrics.aggregateStageMetricsJavaMap()
+          case _ =>
+            df = sparkSession.sql(sql)
+            new java.util.HashMap[String, Long]()
+        }
+      case "task" =>
+        val metrics = TaskMetrics(sparkSession)
+        sqlType match {
+          case "SELECT" =>
+            df = sparkSession.sql(sql)
+            metrics.runAndMeasure(df.show(0))
+            metrics.aggregateTaskMetricsJavaMap()
+          case "INSERT" =>
+            df = metrics.runAndMeasure(sparkSession.sql(sql))
+            metrics.aggregateTaskMetricsJavaMap()
+          case _ =>
+            df = sparkSession.sql(sql)
+            new java.util.HashMap[String, Long]()
+        }
+      case _ =>
+        df = sparkSession.sql(sql)
+        new java.util.HashMap[String, Long]()
+    }
+    if (MapUtils.isNotEmpty(metricsMap)) {
+      val retMap = new util.HashMap[String, Object]()
+      retMap.put("execution_code", sql)
+      retMap.put("metrics", metricsMap)
+      val mapper = new ObjectMapper()
+      val bytes = mapper.writeValueAsBytes(retMap)
+      val fs = FSFactory.getFs(outputPath)
+      val out = fs.write(outputPath, true)
+      out.write(bytes)
+      IOUtils.close(out)
+      fs.close()
+    }
+    df
+  }
+
+  private def getDQLSqlType: String = {
+    val parser = sparkSession.sessionState.sqlParser
+    val logicalPlan = parser.parsePlan(sql)
+
+    val planName = logicalPlan.getClass.getSimpleName
+    planName match {
+      case "UnresolvedWith" | "Project" | "GlobalLimit" => "SELECT"
+      case "InsertIntoStatement" | "CreateTableAsSelectStatement" | "CreateTableAsSelect" =>
+        "INSERT"
+      case _ =>
+        logger.info("当前SQL解析类型为{}, 跳过sparkmeasure", planName)
+        planName
+    }
+  }
+
+}

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/sparkmeasure/SparkSqlMeasure.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/sparkmeasure/SparkSqlMeasure.scala
@@ -20,11 +20,13 @@ package org.apache.linkis.engineplugin.spark.sparkmeasure
 import org.apache.linkis.common.io.FsPath
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.storage.FSFactory
+
 import org.apache.commons.collections4.MapUtils
 import org.apache.commons.io.IOUtils
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import java.util
+
 import ch.cern.sparkmeasure.{StageMetrics, TaskMetrics}
 import com.fasterxml.jackson.databind.ObjectMapper
 
@@ -79,6 +81,7 @@ class SparkSqlMeasure(
       val mapper = new ObjectMapper()
       val bytes = mapper.writeValueAsBytes(retMap)
       val fs = FSFactory.getFs(outputPath)
+      if (!fs.exists(outputPath.getParent)) fs.mkdirs(outputPath.getParent)
       val out = fs.write(outputPath, true)
       out.write(bytes)
       IOUtils.close(out)

--- a/linkis-engineconn-plugins/spark/src/test/scala/org/apache/linkis/engineplugin/spark/executor/TestSparkSqlExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/test/scala/org/apache/linkis/engineplugin/spark/executor/TestSparkSqlExecutor.scala
@@ -68,7 +68,8 @@ class TestSparkSqlExecutor {
       sparkSession,
       outputDir
     )
-    val sparkSqlExecutor = new SparkSqlExecutor(sparkEngineSession, 1L)
+    val sparkSqlExecutor =
+      new SparkSqlExecutor(sparkEngineSession, 1L, new java.util.HashMap[String, String]())
     Assertions.assertFalse(sparkSqlExecutor.isEngineInitialized)
     sparkSqlExecutor.init()
     Assertions.assertTrue(sparkSqlExecutor.isEngineInitialized)

--- a/tool/dependencies/known-dependencies.txt
+++ b/tool/dependencies/known-dependencies.txt
@@ -824,3 +824,4 @@ zookeeper-3.9.2.jar
 zookeeper-jute-3.9.2.jar
 zstd-jni-1.4.5-6.jar
 zstd-jni-1.5.0-4.jar
+spark-measure_2.12-0.24.jar


### PR DESCRIPTION
### What is the purpose of the change

Add support for SparkMeasure to the Spark engine for better monitoring of Spark's performance.

### Related issues/PRs

Related issues: #5200 


### How to use
1. Here is an example of submitting parameters using RESTful API, with the specific parameters listed below:
   `{
    "executionContent": {
        "code": "select * from test1.test1",
        "runType": "sql"
    },
    "labels": {
        "engineType": "spark-3.2.1",
        "userCreator": "zhangyuyao-IDE"
    },
    "params": {
        "configuration": {
            "runtime": {
                "linkis.sparkmeasure.aggregate.type": "stage"
            },
            "startup": {
                "linkis.sparkmeasure.flight.recorder.type": "task"
            }
        }
    }
}`
2. It is only valid for some DQLs, such as SELECT, INSERT, and CREATE AS SELECT.
3. Indicators can be categorized into aggregate indicators and detailed indicators, and each type of indicator can further be divided into two sub-categories: stage and task.
4. For aggregate indicators (using the parameter: linkis.sparkmeasure.aggregate.type), each eligible SQL query will have a separate file output.
5. For detailed indicators (using the parameter: linkis.sparkmeasure.flight.recorder.type), an engine will only output one file, and the file will be generated when the engine is shut down. It is recommended to only execute one SQL statement per engine when using this feature.
6. Due to the reuse mechanism of the Linkis engine, using linkis.sparkmeasure.flight.recorder.type does not necessarily result in the creation of a new engine. If an existing engine is reused, it may lead to no indicator file being output.
7. To ensure that the file is output to the correct path, you should add the following parameter to the Spark engine: linkis.sparkmeasure.output.prefix.
8. Currently, support is provided for writing files to both local and HDFS storage.
9. For a detailed introduction to sparkmeasure, please refer to [SparkMeasure](https://github.com/LucaCanali/sparkMeasure)

### Note
1. The files generated by SparkMeasure Flight Recorder can be relatively large.

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.