### PR TITLE
Fix split sql concatenated limit exceptions by semicolon

### DIFF
--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/Explain.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/interceptor/impl/Explain.scala
@@ -176,7 +176,7 @@ object SQLExplain extends Explain {
         }
       }
     } else {
-      tempCode.split(";") foreach { singleCode =>
+      splitSqlWithRealSemicolon(tempCode) foreach { singleCode =>
         if (isSelectCmd(singleCode)) {
           val trimCode = singleCode.trim
           if (isSelectCmdNoLimit(trimCode) && !isNoLimitAllowed) {
@@ -228,6 +228,50 @@ object SQLExplain extends Explain {
       if ('\\' != realTempCode.charAt(i) && ';' == realTempCode.charAt(i + 1)) array += (i + 1)
     }
     array.toArray
+  }
+
+  private def splitSqlWithRealSemicolon(tempCode: String): Array[String] = {
+    // sql has been split by semicolons, but the semicolons within single quotes, double quotes, and backquotes are ignored
+    val splitSql = new ArrayBuffer[String]
+    val current = new StringBuilder
+    val inSingleQuote = false
+    val inDoubleQuote = false
+    val inBackQuote = false
+    val escapeNext = false
+
+    for (char <- tempCode) {
+      if (escapeNext) {
+        current.append(char)
+        escapeNext = false
+      } else {
+        char match {
+          case '\\' =>
+            current.append(char)
+            escapeNext = true
+          case '\'' if !inDoubleQuote && !inBackQuote =>
+            current.append(char)
+            inSingleQuote = !inSingleQuote
+          case '"' if !inSingleQuote && !inBackQuote =>
+            current.append(char)
+            inDoubleQuote = !inDoubleQuote
+          case '`' if !inSingleQuote && !inDoubleQuote =>
+            current.append(char)
+            inBackQuote = !inBackQuote
+          case ';' if !inSingleQuote && !inDoubleQuote && !inBackQuote =>
+            splitSql += current.toString()
+            current.clear()
+          case _ =>
+            current.append(char)
+        }
+      }
+    }
+
+    // Add the last fragment
+    if (current.nonEmpty) {
+      splitSql += current.toString()
+    }
+    splitSql.toArray
+
   }
 
   private def addNoLimit(code: String) = code + NO_LIMIT_STRING


### PR DESCRIPTION
临时查询中的提交的sql中包含非结束符号；时，直接使用；进行分割sql段时，会切分失败，导致sql不正确
sql样例：
select 
id,
name,
array_join(array_intersect(map_keys(info),array['abs','oda'],';') as infos
from ods.dim_ep22 ;

错误拼接：
select 
id,
name,
array_join(array_intersect(map_keys(info),array['abs','oda'],' limit 5000；

;') as infos
from ods.dim_ep22 limit 5000 ;
